### PR TITLE
added support for aparc-a2009s FC

### DIFF
--- a/functions/03_FC.py
+++ b/functions/03_FC.py
@@ -259,11 +259,7 @@ parcellationList.remove('cerebellum')
 if noFC!="TRUE":
     for parcellation in parcellationList:
         parcPath = os.path.join(parcDir, parcellation) + '_conte69.csv'
-        if parcellation == "aparc-a2009s":
-            print("parcellation " + parcellation + " currently not supported")
-            continue
-        else:
-            thisparc = np.loadtxt(parcPath)
+        thisparc = np.loadtxt(parcPath)
 
         # Parcellate cortical timeseries
         uparcel = np.unique(thisparc)

--- a/parcellations/aparc-a2009s_conte69_lh.label.gii
+++ b/parcellations/aparc-a2009s_conte69_lh.label.gii
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<GIFTI xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="http://brainvis.wustl.edu/caret6/xml_schemas/GIFTI_Caret.xsd"
+       Version="1"
+       NumberOfDataArrays="1">
+   <MetaData>
+      <MD>
+         <Name><![CDATA[AnatomicalStructurePrimary]]></Name>
+         <Value><![CDATA[CortexLeft]]></Value>
+      </MD>
+      <MD>
+         <Name><![CDATA[ParentProvenance]]></Name>
+         <Value><![CDATA[/data/mica3/BIDS_MICs/derivatives/micapipe_v0.2.0/sub-PX071/ses-01/surf/sub-PX071_ses-01_hemi-L_space-nativepro_surf-fsLR-32k_label-midthickness.surf.gii:
+/data/mica1/01_programs/workbench-1.4.2/bin_linux64/../exe_linux64/wb_command -surface-resample /data_/mica3/BIDS_MICs/derivatives/micapipe_v0.2.0/sub-PX071/ses-01/surf/sub-PX071_ses-01_hemi-L_space-nativepro_surf-fsnative_label-midthickness.surf.gii /data_/mica3/BIDS_MICs/derivatives/micapipe_v0.2.0/sub-PX071/ses-01/surf/sub-PX071_ses-01_hemi-L_surf-fsnative_label-sphere.surf.gii /data_/mica1/01_programs/micapipe-v0.2.0/surfaces/fsLR-32k.L.sphere.reg.surf.gii BARYCENTRIC /data_/mica3/BIDS_MICs/derivatives/micapipe_v0.2.0/sub-PX071/ses-01/surf/sub-PX071_ses-01_hemi-L_space-nativepro_surf-fsLR-32k_label-midthickness.surf.gii
+
+]]></Value>
+      </MD>
+      <MD>
+         <Name><![CDATA[ProgramProvenance]]></Name>
+         <Value><![CDATA[Connectome Workbench
+Type: Command Line Application
+Version: 1.4.2
+Qt Compiled Version: 5.7.0
+Qt Runtime Version: 5.7.0
+Commit: 092b7f2f7dfab0f9ea7cbb6c1db2e5dffd2c1045
+Commit Date: 2020-01-07 17:24:23 -0600
+Compiled with OpenMP: YES
+Compiler: g++ (/home/caret/gcc/install/gcc-4.8.5/bin)
+Compiler Version: 4.8.5
+Compiled Debug: NO
+Operating System: Linux
+]]></Value>
+      </MD>
+      <MD>
+         <Name><![CDATA[Provenance]]></Name>
+         <Value><![CDATA[/data/mica1/01_programs/workbench-1.4.2/bin_linux64/../exe_linux64/wb_command -volume-to-surface-mapping /data/mica3/BIDS_MICs/derivatives/micapipe_v0.2.0/sub-PX071/ses-01/parc/sub-PX071_ses-01_space-nativepro_T1w_atlas-aparc-a2009s.nii.gz /data/mica3/BIDS_MICs/derivatives/micapipe_v0.2.0/sub-PX071/ses-01/surf/sub-PX071_ses-01_hemi-L_space-nativepro_surf-fsLR-32k_label-midthickness.surf.gii parcellations/aparc-a2009s_conte69_lh.label.gii -enclosing]]></Value>
+      </MD>
+      <MD>
+         <Name><![CDATA[WorkingDirectory]]></Name>
+         <Value><![CDATA[/export03/data/opt/micapipe]]></Value>
+      </MD>
+   </MetaData>
+   <LabelTable>
+      <Label Key="0" Red="1" Green="1" Blue="1" Alpha="0"><![CDATA[???]]></Label>
+   </LabelTable>
+<DataArray Intent="NIFTI_INTENT_NORMAL"
+           DataType="NIFTI_TYPE_FLOAT32"
+           ArrayIndexingOrder="RowMajorOrder"
+           Dimensionality="1"
+           Dim0="32492"
+           Encoding="GZipBase64Binary"
+           Endian="LittleEndian"
+           ExternalFileName=""
+           ExternalFileOffset="0">
+   <MetaData>
+      <MD>
+         <Name><![CDATA[Name]]></Name>
+         <Value><![CDATA[ enclosing voxel]]></Value>
+      </MD>
+   </MetaData>
+   <Data>eJztnet16joQhSmFUviRQqjj5CYxAVIHpVBKSrmRicIgRtI8JTnBa+3FS5r59kg2tpxzWK0+nlbnf0+r0/S0Wr1+6e1ptf56fn55Wm3evx4PX9p9vff1fPv1uPkvr+3xXunnYQtxR9xmro+yR0zTl84TrtO7n6Y3muYx/Fb0mWrE7RzYoQ73flJJ5ufP8wHrAMeH4wt6G21L5x3FU9jS16NtN/sUY5xG3nJ+cl5G3Y/gVhubsC3NR24cwmcjbyUPo38/ha1a/4H5KewjbrU5M+IGzxWXUOspwzrivI6sKfNo57gpZ9Bo5+IYY9i4jF4+wjUVNt6lOmLPPWqNseXGmKLfzJUyzdezCi7tdnNd/d/tcwmTFcvdNX9DFg1H2KzHBWPwPo6W8pfq0Cp3mr91XqutltM6b8t8rXJRc8Dvdc8ckjnp6cFrHLhxKbGtWS3ixfdrccJa7bwm/r1um4tHZcJinBgsUFgcTgzYn5s7KPaLa/PxeanPuba+r2xfvX/AaFe7D0H5LF3Tx95P38vdFwj3cyT3dOZ1M2edn28133/rrOnZVrlrM6jcNn8uGDfPsUvHLB07zjiO4ivnqeTTyldvP1Rfo867Jfrp4WWEcaH4SP9mAmq+NzX4eGD31W/urQ0+BqX7mh4eWrNb8Fvvv57cku8C6jwPmzWzhrfEnPu7gxwvhV3LmmOmzgdKref4RqyiY8UK+bsVpzpO38oxkuYr3Jz4bji/mSRsVlw1NhYX6OPBFQTvb3KZwuZSryTXPHewuZ/wWNWqxHPHlnk/5ZFyUVkoHNIaYfNGwiAdKyw/hyHO7bg+YMXAyQ/XJ3rlxvbxFnlHzqnJF3NS97Geubh5KPuKV44gi1px4nO3XGyruOlYa2J6xAtbPKZqY1HOOTg8mhia/vDYI+3boo9H26Vts7cPW+X+3U7U53u9TUnbisK/vYqPI8jqPlJWDmMXxkgi6viRa6f0I/Uh9XYmepP4sPZT9cWd5w3HQuTJyE9LH3e+hMegcO/gt/iAWrqHJXGn/EtlXwor1IPZn3kpnN7z2JIz3u8YlQ8yQo3CluOT8PZiq/H1rFmOc74X1qlW2XvDg/GEa885zmtnluR6uAtH5tq8GUOv/IV1CdfcjPURk7xGazXknAvP16KeLTwVcxjVzDV+i7gedRgt3leMcK9PPZ8MYjz0UEnhmDVNPMXtHM7HlQr/751FDI3OR74+9/aSjh9lDMM2GdS6VHPrMaN6s/JU4zKLQ/DVyhPHX82Ttx/x/i3oXxqj1uOiFebDcn618nJ3LbZ0D4Ozp9951mPgWmfse9uA25sZZR+01sVzpIFqTDqnI9Z4jgcYpbx3+xXn/JNY22a1q9X0nz2Xmi3H+M9xP9byGbGZCVkbHYLNkMuLqeu4HX8Hi0VueP0t4ejN4Jm/xqDNWcud5g/tJXljrjRfKe+NFPXMqWWubD4k3s+6EnjNXce6uY/EWMuS5uGumXFzSNblPNf8qPGXFHfkeFaxJHHSeNraa+Zby34PybSdLpqOtopxU8XP1wdjTbhuzgcM1s2mqSJl3TYTXWujnLVxzH0Wa28ypsjYeXvjCvLm3seUjttovji+f4un1N+dnwG4JMKOE1bHpt5eluoDelF9X3T0nuWnME3gsYOHIjvkga8dv+O57NVzDomWxuxd6yXxLmROkM+ZO3K6MRqxurIp+dLrIlNWIy729ZsTm8m1pSGb2fVuI5YWdWk2RgWeJuNSYGiWf6D6m67/ENU6p/k6l2Euab4WeSgx4d+2x+ehb/wbamsPVC+a2KX4I8fUen7ooRF1mu5fx/fi86B1QStknX3zcRF83krnHV8zp4GmXV3r9/YqeTet/y4vrBbbj7LWu2/VPBbmZqp0jo4+P+PcpHhakrdNxkvN36h+uJ56zkWOn6iR/VB8cXxA9fKS8yXxAWP1HJ/oRTIO0UfvOTaLuV8MdZwusOf8jMad8uf8dOdmnj8+eP1YU95NPPe1Pgc24IS8d+fSHswKxtI5/w1zD75GbPCaxozNmAuypZw3n1NqJmTErgExxrv3JDLiQRkdeJqxjMJR4GnOkLBI81vUIcQIaxoxHnzuyZBbW/H0rMkpydsyX2m9yjJXbW3MYt5Y5sByUdYwJTkmx9jcNViPmLXY0njbD5tYIU6UJA7sD6WNoenfsh+3D6e9dczFaL8MbXd5nV+eVqd9WdPL9ZGr1TuiF1yb/UXwuVRxjII/qM9DWauJr83LVXef73maXq/afPFv4iMQHL+lz83S/Fy6t5yv4tx9zaunF8hg6Sn1Bd/zrEONqeiH0p8o6/Hp6YXjGauBekwa+JqEn6k8fD+fqDkQrpxy7cz4gQ80PmiTYyvx17zdvJayVyTlI/tw4i7xa315M1uPw4i8q/3tOWF8PhojZIUahTHHNwpjjq0Vn2Rse9auVK+WXDWO1kwcnvSauyvPN4cHj6QmuXUJL4553aDEkKyfSPJ/7i7Ccv+sXWD5DXJj+WHen/y59SJm7pgrFZZzU8lJzds6Zy5fLqckXymHJldQXB+k5uLmSdchNTmwdUxsrVMSH1srza2lamJPL3zuzQseu7bmm4ub3RcmeswYd8rEksTLxYpru9pYcS1YEyeuTUtiwHVtco2RdXGvftw+2va1z7F2uTan/e29EezzUt9SzNx755fL8/CYaju10fpwfZRqK9Dqg6bzVNbmqNP5v7xWb3zN3sLzr01SF1H9G82VHzn7au7nW3AMyUL2HbhvjeLpbn6+Ffwix4dRxN0Xe/OaeRmAV+sjtu3Nqx2LET0smX+p7EviPn+rNe8ZCL5XagtfW/Jiec8EUbxZsVJ4qKy5NlpOLSNJhHNwrxpq+MI1xShskDG97hmBaySm0jViM5apztKSp3rt/Ic4ejOQ1jJ+mfe/kFObz2KtjJunlssqRymPVfxcDokHanwvdquYMLZlvCDLWN5xqGvUuRia/tK+kn7cPp7tf6ska+ZQ59e81lN/efnr7es3e9P6Sv319mPlaRQvVn7mWIcGvFgO8J6JlxZ+DkDpe0ofa0xe7AUNyU9kN+e38GDMvqYwc9ixucwUu6Yl3hq3kLHErI7nUFOM1yqWJddDDz300EMPPfSQVtvpImqbWtu0DeyXKpcnJ257qbzjP1TWhPwNwijxrGJZxLGuEycvN3fsw+lH7QPbBc1/809sC2PHfR5rE9vB408tFtamxFLiq72Xzomf9w5X5da/NweZSvdCoqYDTafd9THqTBD0h3mUeqv5o/pKPY7gzdpX9EbxhPmy8mbpi+ql11hJxqi3n17jYz3frPcfjQ9PL1w/VmNR80L53vlr/Bb7dI2fw735sGPnMnMVWFNpuSW11vDW2Ck1blXbEjd1HvdihPLmnHMo+GqcMX7LmnEYJXzWXBjbz/sL5/JgSvmoTOvpIm+mGk/k6MkCGVK14Cjl92bpnZ+a2yN/r9wj5uxR2xa5vD3F9729LCH+kuKOHM/Kr0cMbhzNfJMcJznHdLj/PiTTyVDn96tWz/4q/f+UP7/VEeaIkabdveJnPX7/x8oX9Ie9H3NRmTC+nr6owpgpfUb2JK1DacznfWwAThP9Bi/xuNeb4496uPlOGoCHzTxo7WM9YV3R84ABOEtMozGLzrUWwhkU/pZnKZxRD0Y9nyenFZs1nyUXZJNyWswzin44EbXmyXGkLB7jdacCC2QagWMScFgzuOQneucyWOel5rbMJ84pzEXNe9PWIB851wLyeOYIa4XxEVs3tIiZW5e0iIeJGpMjqzhpTOz5X9VJUQNpX0k/Tp/Qltqe2rbWLn6ea0P9nOodvgf7wjxkHQna2wj7/RQoTqywhT7rL9/S30iDWr0Q9f4twe8UTUyPFt7IvhJ5+qoyP/t44nrTekq/2z28UDwFPq0f7FzIy0vJE8fDSF5SP1ofufNTT/7Uh8YDyu/IjEnKn70+GJy9eh06KP+D+ffzltjOL7ePlpzxHNeqjoExymJ/S8/FmzIy2UqcEjYNX+2ahlszq/ElXW8Jr7nIXAib53UgmelZUCcBF7dGnmNWPfbCsfp+7cVS44hrBmQGAQclv+faBTm/w/w082ydl5OTmLfo0SFnMZdxPtM8hVxN/FitIeZy9IwtPYZYMR8dYnrEs/JqEUcbw7qvVz9t+1Ify3a1NulnU6afkdLrh1Sbf0Z6vuhzSnRMnhM0Pee1PV60ece12l2Vvo66Y0R0E7OQz0Lb3VXpazhWn4e8VpOT9jxNrxfN3l6/lfGazsVmnoT+JuiF4Svk0fhZH6+PUVbeqHMz9SP1QZHGl8SP1JPaB8ETxU/NRzxGU+aVlxfKcRB+H2H8mAfOvGJ7SX1MBB8Ja+77UutBdBxg8g/BDueBkt1i7kg9zOcROQ/Ecywtq7T2IzC34LWsL5VZwmrNSeGV7m9erDleDqPVMUBVS+LxaiQ2i+9f1b5idHyPn3O/hyhMtX7S44WYJ2wVHov82vFyY8hwuDMcn27XDzT5a2N0vM8Lpcp/BPGR2BTFnJ/TRdkcyjxY3pgzlWUeWOdSvk+HnLl8nw75KLksctbypN4kOak5pPWUxqf40sTGxit9PrQsOY/6eGGziPMTQxpH0/+IiFLrXJ8My7wGj+UqsIe1f0rbEDveK8i1j/cB4H0Fbhvs8yB4nyH3/hb0n9cFwHvxPAE+v1kj+/6/a9cfF1H+/2dvTe863aydH4z05i+OLwt/mzedTgeGdnXFOQgFvWrnBZxjWK7c/Mc+o/RL26exrHxRvWlU8oWNmYUn6MvDE0fW49Tbz9LGp3SssPJwSrzkjkkpF7VtzkuUxsMp8YDVi3IMpvgp9bXyYKVW/B7s3PGTcvdWa+awtWTuXV8Ob29OKmtvRgonNc5234eRE8eLUcIWWFKpONLrk+/X2DVZjaMmMk9BKRelPmImeP3GYAqvNXWCbDeMxOvNyAOvr7Usd/VisGCK8cK1uIpHwwHWA0ZgkHKI8xvkpub3yEvJbTXumzebnNQ8lDWn+D5lXLXrXWiuw72WlKcU3yKHJ3+JWxPfoybWrKVY3HhWsSzi1GLU4mj6U/vCGJQ+WF9Ov4euWr3xtH3n6ZRoevNR1uMOV/U66lAW67cyDzJhseBYePia/vn7wrxBX3FdkeKH6onjS+ItzvecL856cdDNenzGD8eXxAum6EfqZfbzLy/q+IS2Ug+pH6mPmheKp9hGwi7xkb1/RfCAeYmfS5glHqT8NbXgR++dIPtzD/4Se/a+lQF72LTsNd7AGQSft6x16jGtdY43Vc+5DdfnSKwCXgvOlLWm3HdqE04uI5HTio/KyOVrXUMJnwXjErnidXhkmp834KIw/bA1qBWFQ8K0ZBZrBmktQvxafioHNz917c4jf4vc2NqKZ87ceo4o3/72Mc1hkm+fUSZuz1zi+Iw83jnEcTvGxmKeD1dZsMJ4kpilWDHeT1wGGxYraP79ixi7EicX444xE4PaH4vB6Zv29+wn4eS0p7attaNwUj/PfcYdI+lcstDpPa/c9/z5v4tWbzyN4uuU+Eil9dXL06ngievLy8Nv8kPhp/hYkpeaD46XUceC48Obf/7bdSE/xUPL+nO4W7FbzxmKBw7f/N+uIO958ebYa0yt5waHd4S5XGKNMS3nq1VNIWuOMb4PH7myZEzrKeHxqqUFiweXB5sV34hcI7FY8lBybY5XebFQcudkxYH5o+SHkua1Eidnj9yW+XrmHcljq1wt8njm8B4Xr9geca1jnqeLrONZxISxNDGxOJxYuf6luNw+o2jz30Xc9pR+aVvYfvVRjxnaRGGxSp9TPiu9l3sdtd09sf9PpPObXHEjtVfe04C+YFzow9ofWQa+0piQvbkf6Evgc/N+q6bMUo+VMap5ym1dfRHGJpVma+kDGxMLD66eGGPhuan3z878qQ/JWPTkxjxQfXC5PT2lsS1r3XoejTg3SluJtbT18jN6PcMmZWzlR8vnWXtqDuyz+JrSN/derl+PeQfzYLl77gtY7Us8f/U40fvcZgSGv5i7R97WOVvma5XrN+TwjO8VewkxLeNZxQm/H6GNo42h6S/tG387g9V393T7exWE9uRxQtaRpO1q+1jtPMtaq1c7fe6vgq9rv/l+3gtVi+v9O/PPtyr+Fg14nvsNl9LvzGO/NW/m6znvCRNkrvFLvOXmiMUYlTzNc5bgiSMzT888Pzf7pZGX4CM+5vbhyJv1RuSHPqAfrQfo5W4/So4v0ceNFyZ/bkw8vNSOp1oP2DF/CR5q31uWHijfZ1bs5rUnfu+Owu7BPQxz/D5/vj5y5rQ1s/RcrCVnlbVyTtiaVcIpOS//zYwec9GK745pEDbvWnkwaXm4TH+FhcVhvM9bMbQcj577S6+6j+DVe4wt89TyWefJ5fPIk+ZYcnyvMVhCzL/A9tBDqWrXgLX1J859ic99XV28Sf0xfFl6OxGu3cW+mJ6svAVPUR7z8Df54XrReiN7EfjReuH48RqTJXkImwc/1Yv1PLJmL/GTuCvsHrw1fm3NWzCn3NJat2JNeaXfxy15ozTnRQ9OJSN4HI4v0chsnny/jcmDzYLHivHkwDMKB5fl1JnDK3fMX+LxzD1CXpi7tdcW+dI57D2PT465WuVoFdsyh2nc40U/sY4XqRiPeCx23MhWEItJG0cbQ9O/0q/Uv5Qz1w9tO+Hithe1y7UZTOn/h5RqvV+A3nHVvC3Cq4Gv4fwhniahr64+Yv7f4GcHhHiZEk+bb6Wvo0LM9LU7d/o68TIlSpkpcvdQkgG/iScqbwN+yAXnnTn7zqf2qCdjLZF7Cczbj6tasGp4e7GWmCETplactdqOxJiKUsPz7qq7GB+I0s+UfDnOIhvGVZJhDSFTqpZcE1CJic1lwGTGo5z/NRb2eEUmAZ85xwIZ3PITeHrl7pG3dc5m+T7a5WqRxztHj9ja+KW40tjWMS3jWcWyiFOLUYuj6d+yH7cPp722HScWpd6G+h/7X3Ih</Data>
+</DataArray>
+</GIFTI>

--- a/parcellations/aparc-a2009s_conte69_rh.label.gii
+++ b/parcellations/aparc-a2009s_conte69_rh.label.gii
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<GIFTI xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="http://brainvis.wustl.edu/caret6/xml_schemas/GIFTI_Caret.xsd"
+       Version="1"
+       NumberOfDataArrays="1">
+   <MetaData>
+      <MD>
+         <Name><![CDATA[AnatomicalStructurePrimary]]></Name>
+         <Value><![CDATA[CortexRight]]></Value>
+      </MD>
+      <MD>
+         <Name><![CDATA[ParentProvenance]]></Name>
+         <Value><![CDATA[/data/mica3/BIDS_MICs/derivatives/micapipe_v0.2.0/sub-PX071/ses-01/surf/sub-PX071_ses-01_hemi-R_space-nativepro_surf-fsLR-32k_label-midthickness.surf.gii:
+/data/mica1/01_programs/workbench-1.4.2/bin_linux64/../exe_linux64/wb_command -surface-resample /data_/mica3/BIDS_MICs/derivatives/micapipe_v0.2.0/sub-PX071/ses-01/surf/sub-PX071_ses-01_hemi-R_space-nativepro_surf-fsnative_label-midthickness.surf.gii /data_/mica3/BIDS_MICs/derivatives/micapipe_v0.2.0/sub-PX071/ses-01/surf/sub-PX071_ses-01_hemi-R_surf-fsnative_label-sphere.surf.gii /data_/mica1/01_programs/micapipe-v0.2.0/surfaces/fsLR-32k.R.sphere.reg.surf.gii BARYCENTRIC /data_/mica3/BIDS_MICs/derivatives/micapipe_v0.2.0/sub-PX071/ses-01/surf/sub-PX071_ses-01_hemi-R_space-nativepro_surf-fsLR-32k_label-midthickness.surf.gii
+
+]]></Value>
+      </MD>
+      <MD>
+         <Name><![CDATA[ProgramProvenance]]></Name>
+         <Value><![CDATA[Connectome Workbench
+Type: Command Line Application
+Version: 1.4.2
+Qt Compiled Version: 5.7.0
+Qt Runtime Version: 5.7.0
+Commit: 092b7f2f7dfab0f9ea7cbb6c1db2e5dffd2c1045
+Commit Date: 2020-01-07 17:24:23 -0600
+Compiled with OpenMP: YES
+Compiler: g++ (/home/caret/gcc/install/gcc-4.8.5/bin)
+Compiler Version: 4.8.5
+Compiled Debug: NO
+Operating System: Linux
+]]></Value>
+      </MD>
+      <MD>
+         <Name><![CDATA[Provenance]]></Name>
+         <Value><![CDATA[/data/mica1/01_programs/workbench-1.4.2/bin_linux64/../exe_linux64/wb_command -volume-to-surface-mapping /data/mica3/BIDS_MICs/derivatives/micapipe_v0.2.0/sub-PX071/ses-01/parc/sub-PX071_ses-01_space-nativepro_T1w_atlas-aparc-a2009s.nii.gz /data/mica3/BIDS_MICs/derivatives/micapipe_v0.2.0/sub-PX071/ses-01/surf/sub-PX071_ses-01_hemi-R_space-nativepro_surf-fsLR-32k_label-midthickness.surf.gii parcellations/aparc-a2009s_conte69_rh.label.gii -enclosing]]></Value>
+      </MD>
+      <MD>
+         <Name><![CDATA[WorkingDirectory]]></Name>
+         <Value><![CDATA[/export03/data/opt/micapipe]]></Value>
+      </MD>
+   </MetaData>
+   <LabelTable>
+      <Label Key="0" Red="1" Green="1" Blue="1" Alpha="0"><![CDATA[???]]></Label>
+   </LabelTable>
+<DataArray Intent="NIFTI_INTENT_NORMAL"
+           DataType="NIFTI_TYPE_FLOAT32"
+           ArrayIndexingOrder="RowMajorOrder"
+           Dimensionality="1"
+           Dim0="32492"
+           Encoding="GZipBase64Binary"
+           Endian="LittleEndian"
+           ExternalFileName=""
+           ExternalFileOffset="0">
+   <MetaData>
+      <MD>
+         <Name><![CDATA[Name]]></Name>
+         <Value><![CDATA[ enclosing voxel]]></Value>
+      </MD>
+   </MetaData>
+   <Data>eJztne914joTxp0ObgmUcEvgA/m+JVDClkAJWwIlbAmU8JZACfdzEuC1WJQVw0iav5Kc4HOeQ7Clmd+jkY0tcpJp9/I6bd820/60maaPzfR7ep1W88/H9/n9vB3n94fzZlpdNtN2fg3tg1bzcUz/zseiwhZf48/ry+Zu32hbzR/UuqL9xV6HD75CHYPC+AeFLf4c34+wRZ7jx71qvqJytUvnJZyfUSONA9wC23fxhXnCNJqv9Fzi+hl1i544fkbevpKX2jVgCVvt3B/t8wlutbk0Mn/tHBiVvfa5N+J9DeWzbCTeeP9a4x2BOb3fHpkVPhtgfL05S2M5AiO1ziVGL3bO2GF8Lbgwvuu+DJ9XvWvPzdecBK6mPI3GKD7na5macWRYwqblSNc90jUVKofVGGDyHoNa7gcGI9+lvNmxd85ZGu/RPUrnkGseoR9vL57xvWJT4oY1TMuYcV00bJS4lFhQ3Fi5ODk2bhwYMxfjwOgf15HTvofEf6l/2vdhXbqg6lo9EoO8zi9ob9muteK6f/oz/D4ACq45YTpe/mh6b6fj25/v4MJr/NlThzcfUdYMqNdBSe1i/VrXDqo2/lxPUT09UXxx/bTwdOUueKr56+3nk61SG2qtenmhcnPmXM96tPSxBA/wmu/JL/XA4b/7fqHzuPdm13CX2EnfjzdmrXFTmLnsnszWvK7jO9W/L6NyW3JCWTF6cXLrnmPtOYZxKzF6cB3eHn+XsTYvseMeXOkWnqHS3ClDideSBzJhW6uxovLE/HH8PMaIw1KqlZbFkkPCchAwWI+Jdf6Rcx/edGOO5Q5xc7lhPk3OXG6PfNi532o8sXzaPNFP7ppmcT6ma3c5TxbxPWPn4kviwvVM65g5Tkm80n2LBZskBoyjjaHpL+3r1Sft59F2iRv2fQ5Xh9Pm87W1tpje7rVD9lnK+3slynce2vrVFL+/gzKtH6ybg6eUO+cJepN4Lc0XqoeQM75Crho7RxQvFp4smbm+uOf0aF6iH8n1aRT+IM119it4gN9BBT3527Ivcc4sgbMHsxXvk9WOb0mc343Pkm0yPMdH4IL94jOWFROFK9cGPvdZ8jz4Ln1PjbBoedS/S2HEYpVfw2Kdn8vglTt37G6fYV6WvnDOzzFu6W+EPJ45Ws2DUWO3Yh0lnkecXjF69G3V56nr9X4d1sdOG5YOFxuFv3sHZR2vpO3snaPjPM+C4L6f06takvr1qptV7dI+MFb8Hm4EXxxv1TlH9GTli3IelPpRPUWN4Afzx7ouZLy0mGfWytVm6T6Wxg/n1ZL4Pz/vbvyjcwfWJbKj9x1C7v2pzThbMTedx0zedCw9WNP5SmWFzC3Op8jA5fRihFxs3fiazzcmnzWjmst47Ex4RuYyYBptjEZhac0R2qav1gwwX3jOx3KYz4mXv2sQtdweQtenFpg3rudg++L+7HqcMJdkbckjT2kdyyo+Zb3M2wuWI+zz8IAd81pPpMReQswRY7WM4cEg7SsZP+nc/e6K3+dYaBs+929K9/+a9MrF2iW6tgu5b1ol90QWazi7U1micYv9Em6qgj/L+tWkqd0OqVWpdmvpeDb2lXqDnnr7knqDfaEnzJd4/iv8xPcUr2kbzM8O1qlhjbj1g7XBzq8etaF6wfan79F6WFxrGwrjXwP+Jfgo1WARXirsw84pBvdQ/EzmITwoeHucB5R70RHG3oPRmnN0Ruqzh3Suali92Ky4RjpPJM+TnkxWz7wWPJ4sHhwSlhEYKDwt8lvktmRolVeTU+uzpb9W3lrUbbT4nDx7J34Jb9hKuaTjkItpFcuK66mnvBXO95VA+/ma3UqH80al9Umn3Tmv2GZ16aeaf4+arIP3jH7Px3NazcfvdElec8rMwbjm23t+auboGvEDNYo3js91plaYt/Da2pOkhp/nesVTqt6eSr7urnEELyN4onrJeYJ1G6026OdP8r1Q7pzq7SP1U/osLV3He7NHcfl7XJMl7CUPo3OPci9qxdyDWzo3ejBTWEeYH1ac8B56NEbsPt+Kb1f5zKCwevHB5zwq07rAZcFYeiYt8VKYpHw1psiV5evAkx034/GRsHwyMTUCB4chPON7jEOOJbfO0CJ/aZ3DI79FXm5+7ThL8tY8Wvu0ylXLR10D1OSxzIHl8fRgyb0TMHPOXeuYI8aixoDrwlIWdI1Z0V/al9Nndd6I+nCYqm3PG1pMwbwdWf9Mr8NoO48tpvC33n7Mx4P+u72WdJjbUzVdcO3e81qFdVOOKjWIf98u1X83r5im+X7cTSF+ReuPzV8FD8krVr+vMDdz89PTWxjPqFo7a28iXx8bEjNsR/En9ajyhPBh7DlZ+Yd92X6Y3Jai+i+yp+rkA3rJtiuxY+rop+iBwq70skaUa1eLcbdfwl7xg7Hm2NP3peOoLyvu6ZXEbCWzMb8Jxl4ic+4YVfBey5qX6oXCCbUExtE4ezFKuUbg680G+Wo8rceMyuPJxGEYlUf03G/Jcns2V61DaDluawSl9ZCJce94PG9M8sO1G0reVJa5c/lhzmpusC6TyxWVjmUuF8y7f0fyp3kr+bgK+aK4+eJ6nTTfNSchl0Weu1xGeTg5LGKnOXJrpxbxpbGlzLnYtXi1mGncUixOvKhaHGosKyaPGBQvGn6rfukafK09XLP/Md1/N5Eeh/ox/f2+Q9tOe1yr4/v9dxvbU16/pse/1VRqX4qRvs/Fzum3QrsXug5hHmW0Ct9bKrUN413Q7qOuq6fbq1acGnDrTplTtbbV2hbGoZWf3DyX+MrVOx5rWSfozdJTqpoXL08cP5TzEhN3XngpvW5ovPSWhv/poT//d2I/GLU7OHEfKtqC11ybXFwr3hqnRJa8UR6csBYa1jj/PTkfuIn3tFj9R2XswUd9PmjJBdlKfD3HLCg8e/Uer5QlVetrScqDPaOG/OlrCxbKs/N34ejN8B1zf4ecLfO1ymWZI7cGaJUjt9ZoyV6K7RGX0r8UL41LjZf2ycXbEfhKfXO+NTGs4lgzSPtK+nH7cL09pfs+YBvuiYFWp77ahXXLWfG99juPkfxFb9GfpbenLz9Puy/gB3qyqFEPD79uc8zKS4zX2kOUhY9fQK09pF403BwPubaS/qm03BQP1P6lOBJ2bU4uO7W9BS/GzGHgymOcPThLvJI43qzrFx1fSy2B8amnnnrqqaeWqO3pz/e26c9bg/uPNAYWH5PWA0eesUfJoYkLY+fmiTSuNsZT7RWeHVr3lfQLfbjnAfXcgbFzfSjtSm3Csdxx7Fjch40X3Bffp32ifk/5tdWg/bxPKuz7kFSHuU1Q2OLPOe3Pc81e/rxGhfclHc6Pa+cYh4e31F9Nkbfm6XA7Hl4xb1b+rHyl3mq+UmG+oLce9aJ4yfmi1KrH/OPWJufHc955zbPWtZGeM/C8l/qwml/SetT4reeV1fWLwm05lyyvvRr2EocrO4MZclOuiy5zxZk5cqP7X/7+DXqMDR7fM+dFUMjDYc3xYcI40XYMVg9Oqrw4Q+zWnL3GkMr4FdisuWpsI45XjmF1GmOMAkeUB0tQjB8Z4n6MwZMljZ9yYPm9OHKxSwyeteHkr7FIOWu5S2OhGSNuTouacL1qc7bKo62jRx7P88E7/oixlxDTO1Yvj9r5SO2PxZGe09Jrz3fWbnp9eJ/ug8c/x91Ah8ujdm/+Wl3+vua0Pum0Oz+q1F76P0MksvLG6bMUX9K+KcNInqyUetPUt7cPrtelewnyvta18pBeu9P3I3ugfib15pSyjzr2Sx3zGntvNi53b6als7bkDNvojFZjuZ6fF6/74ytV3PZStpJyXKXjFjWtcUm4lVxqJgWXyxgJebxYdkoGCUfIuQNzOu7b5bwaMtzlyom55mCWV5DfPDcxf4h7/UyxyknIm4stzlfLqY3NyWeZo5SrQY6wWcTOrh8qYpTEic2Je41tFAeLCfdp4ml4nnqqpn1ljpWO546l+8PPUXAfPE7Vj/kzgKSJJvj/USTi5FpdCgrfATG1C3+Ht6Dpgv9/KoqovqIsvNX85Lx18WVYp9b1ynmKn+tLq1PJSyoLP9FTby+YH66PqBY+ivf3Qm5vH2QPRvxUD1z+6nNkI37u/GnJnWPnfl60Zsa4R2fWjrMHb7hvRPffckrG9fhuxxn54j0uxshlO976WnDm7sWljJEvlZSx9rxgxSjhs36msWIbggtha8FVZXobkOetDQ+VxYNDMiY9x8Jr3aJ2zRatmTDzm3lm5M55Fq8TEfOWcnnUuJbPI5e3r1oecq5KDpM1RGF8zViZ1ACJ7bGmahIviWsWrxCLy2XB1LO/Zb9aX24fTntqHSjtam1q54q1sGecVNt5PqdazdcIivaIwv7p41E/Z9+YDnN7rtaXuqZzXcdTXQ9xZ+ag+DOFhartGVeubv/NtYKaZuaa/pm5gyhtHxRyVHT180HzV5qXVD+pJygrT3feCPUr+dL4YXkz8JT68vbDmpMGdfL0Izq3Mr4o9RmmLpif2yvlGiitCdWH2s+J70F7DbPmr3lI2eNnvfX4azxQ2OG9ijW7hL/EnbvHsuSV+uAyY+ytmCVjDJmtWSW8FFYPzhyrhLP1WOY4W89P7vlU4+vBdv1d74ZsdxxhE4yZtJ5YP8k1nXPtjj9L86J6eb17JuV8pogFa3VjoLCYcmTGArI040DyR+298xdyB6nGIMZJ3xPzYrlZ+QjxxXkVsbP6qPhslO/olCvmO54eZZkHjT9vZrkyOUqeOHkpsdMc2Pvca9RPZp6aQrzRY8Z4FnFhLGk8izhhjVvbP42h6Rt+rp0fYS0dW6eP1wjYNtfn4XsDsF5fykFpe20vaFdrwzkG96d5KOtjQdS/pSzVr5e/f18f+3l3sRP6nUD4HQyNPjaP741V85W2sfK3D3/zV6H/zTFq2oe/bctQnBdxbhyQelrOlyg4L6G8zo0Wvmqqnbtc/6G9lyc4R2q+UvZajaFP2N6jPrVzoOaNOxapRvFiIW8fLfzsDc8X7rXWwmPs39JD5M3tozJb8nM/8zj+cjWzYPfgznGOzE3VUnjD1ps3Mny1sZUw/jvfF/97uzeGrx6Czxe5547wPrLVZM1HEZVNwps+q6TPL95cOcbac1UrppRrJCbKs+dIPK1YlsDRgmHU/N65sbWZfe0aNv1ZD5LmwtaFijmZ+SjrUNR8pdy1PKlKeaBa5OHErObwjN84tjSHS8xCrN7xrNaLLeJo1681/aXr6NI1+Kf4+n3Tbh53qO3FV4cPO+X8ldapSjpMtP+ju/2o/E/KMKeFSuPEmsR6/VZ4o/ir+dJ4+4xxuZ9vcR5KPZV8rd82V3n5gnMbnktWdYo+UlE8hXbsGhU8SWoThPFz/MC2pJok8w3zI1lnofgoecm1pcwtTJ4+qPV4OM78PJB40NSB5JPpgcKcPk+a8hfmugU79gxO5Y8eUOb0PDXm1jJnvSjvfaisFswW92oc3p6cLVi9OC3r35qxN9+IY1diEl0/G3Ltw2dxIm8uS6YWPBgLxuXFEvJgHJiuLGGuEe8lqRyU3HccNwYNi5QB5tbm13qX5OfmzOXl5v4OOVvWk5rjmPFEzafJcQD34vA9JUeIXYofFePDfVbxcyrFHC1uLSaMy4kH40hj1eLUYlnw5PrDONL+x0LfWr9cf68+aT+Ptto2HB9eopzPXGnusUrafZQF6+fpa4/I25dUYau1wfxIfdX8WHiSepF46uWH4uPTz3uizvNN6uPOA9QFeLvtH81H0UNFnh7Ec0npYag5xORfyryx5m41V1LuJbCmzJ6crVljTgmnJWvKox0/L07IMhJbkAWLF9934RqN6SvwrF5ezVm4ucNrKguG1FcpV07a3Kk4ebX5uXksclvk5OS1ykfJaZmrdb7eebxzLCW+1/i0iqmJaxlvnXxGHU5/VOuTtol9QpxSLKwPVIyRO16Tpr+0b+y3YvRdvf8Vdnw3j9EuGae0fVA8jsmyXa2N5Bh1H3Zse96gfzfo+PFXcR92zF2K7zao3pr6wbwxfWKeuvowqB+sVXdupSeun/UI81DgJXBrtpZeAmtQ9BHfW20uNc14gAqbpZe4QQ9pTokfjLvlhrFT/XDYLbzlYuTYcx6o3J7zKM2BCWOmsHjPoxwvNoc4MVttJVYqR+tztXSNG2VbAmPYRuaTssG21r5GHLMcUy++keZ/6Rrdm6P11puhZ/5euXvkbZ2zZb5Wub5CDs/44X8heMT2YE5jWcS0ZLSKk9ZDE0MV56wYl/P9/5Jw7Qc4q/047altCe1q9y2l46X7HqmmDz/9nF7vdHzfVP/fO1dYTIpKMVdv5f8luS8IHYcX3f+Yj4K1k/iTeMr5irL0FDbJPJF4KvnSeIK+oCfKvA5b9EXxkfNzePP1wz1fNV4sfEA/ktpofVjya2si9eHhIV7TWtXA+rwI8mD3PBc47Fxmz/mfsntwe4+3hjdsNVYL5n/n+5WgEq/FuI7ESr231XIGUedAvK5z+Kw4S4zYfRqX0YMP45I+w2j4amxSJu25UhurHuPlxeTF03J8SmPSkmWE+WI9Dlb5W/jv5buHZ6tc1Hzp+pQmFyWfVS5KniivPBY5avG96rGkuNYxLeP1jmPp66mvLYvvByjPRPC7D3idtLiuSb1p/JV8lfxqff2o3ANrPEl9afwFPxRPUl9fxY/Gx1fzwvVD8dFyXkn8lDz0ONe5Hmo1GJl/qXNnZOYc9+jMkF17bUyPe/L+nOi/I5LjTDUCJ8bagk8zlqOMYW1OejJKuHLtR+WyYrPkseCSzHMvHgrLCBwchpSFwyTJYTk2PfN7584x9Mr5wzl3mu8HkGdOmMsjXy6PZa4WXjzje40PGvdFFzcXUxoXxoBixcrE6BGnFKMWZ1vpW+pf65vrI+3n2R5rtz9trsrFDMdguy3Sv7fg3zoJ+mc+D0bS6rIRCfM2mkdrX6P4k3jaXf6I4q+HT46f3eXeD9fbSJ52iKKnkfyszgn3meYj1TrhXTN8Wfu74waeKB5ysq7V6tY2fa1Jw8+pCXm+MKThpnpIx1PLazXmNS/pz1LGlsxQ3ryWrBbMI7P+nu+No0bhDCyjMOZYU6YR+CCnlm0fnpluiu+tGKlcJSbIZ82F8Rw684T8QSlPVI7Fgwvm5nJYseUYNBxcnhKDlqN3/hpLi7xY7h5+W3mNGiWXZc4Wc7VnfG2OXnEl8WvjwI05YiyLONoYPfpKmLl9OO2pbSlzcjD9H9ywv7w=</Data>
+</DataArray>
+</GIFTI>


### PR DESCRIPTION
this adds missing `aparc-a2009s` atlas on surf-conte69 AND uses it in generating FC