### PR TITLE
patch for aparc-a2009s and general robustness

### DIFF
--- a/functions/03_FC.py
+++ b/functions/03_FC.py
@@ -265,7 +265,7 @@ if noFC!="TRUE":
         uparcel = np.unique(thisparc)
         ts_ctx = np.zeros([data_corr.shape[0], len(uparcel)])
         for lab in range(len(uparcel)):
-            tmpData = data_corr[:, thisparc == lab]
+            tmpData = data_corr[:, thisparc == uparcel[lab]]
             ts_ctx[:,lab] = np.nanmean(tmpData, axis = 1)
 
         # get correlation amtrix


### PR DESCRIPTION
This patch ensures only labels found in the label.csv files have calculated FC (eg. it doesn't require only sequential labels). This adds general robustness and fixes the issue with `aparc-a2009s` which starts at label 1000.