### PR TITLE
[FIX] incorrect atlas name for glasser in docs

### DIFF
--- a/docs/pages/02.structuralproc/index.rst
+++ b/docs/pages/02.structuralproc/index.rst
@@ -259,7 +259,7 @@ This first structural post-processing module registers native FreeSurfer-space c
             - aparc-a2009s
             - aparc
             - economo
-            - glasser
+            - glasser-360
             - schaefer-1000
             - schaefer-100
             - schaefer-200


### PR DESCRIPTION
I ran `-post_structural` with `-atlas aparc,glasser,schaefer-100,schaefer-200,schaefer-400` and it led to many errors and the job seemed to enter an infinite loop of trying to transform an atlas with no name. I traced the problem back to the Glasser atlas name. See this part of the log:
```
[38;5;75m
[ INFO ]..... Selected parcellations: aparc,glasser,schaefer-100,schaefer-200,schaefer-400, N=5 [0m
[38;5;75m
[ INFO ]..... lh.aparc_mics.annot  lh.schaefer-100_mics.annot lh.schaefer-200_mics.annot lh.schaefer-400_mics.annot [0m
```
In the second line `lh.glasser_mics.annot` is missing. Then I realized that I should use the name `glasser-360` (as also the relevant files in `./parcellation` are named) instead of `glasser` (as listed in the docs). Using `glasser-360` there were no errors and the job finished successfully.

Here I simply changed `glasser` to `glasser-360` in the list of atlases in the docs.