### PR TITLE
[WIP] Deployment of HTML documentation on alternative webhost 

### DIFF
--- a/.github/workflows/doc-github-pages.yml
+++ b/.github/workflows/doc-github-pages.yml
@@ -1,0 +1,49 @@
+name: Publish doc to GitHub Pages
+
+on: push
+
+# Cancels running instances when a pull request is updated by a commit
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  cancel-in-progress: true
+
+env:
+  SPHINX_VERSION: 4.5.0
+
+jobs:
+  doc:
+    name: Publish doc to GitHub Pages
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup Sphinx
+        run: |
+          #If additional sphinx dependencies are required they can be added here relatively easily. 
+          #e.g. if I wanted to have the copybutton for example, I would add: pip install sphinx-copybutton
+          pip install sphinx==${{ env.SPHINX_VERSION }}
+          pip install -r doc/requirements.txt
+
+      - name: Build HTML
+        run: |
+          cd doc
+          make html
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: html-doc
+          path: doc/build/html/
+
+      - name: Deploy to GitHub Pages
+        uses: JamesIves/github-pages-deploy-action@4.1.7
+        if: github.ref == 'refs/heads/master'
+        with:
+          branch: gh-pages
+          folder: doc/build/html


### PR DESCRIPTION
[WIP] **Please do not merge**

Rumor has it that your online deployment of your documentation seems to break from time to time. I am not exactly familiar with the way readthedocs works as a hosting service, but I am not sure you actually need to go through an alternative online platform to deploy your documentation. I am highly unaware of your field, so if having a readthedocs hosted documentation is a valuable thing for you, forget what I said.

This tentative PR uses a GitHub Actions to generate your webpage. It automatically setups sphinx with your requirement in a CI instance and deploys it automatically on a self-hosted github.io webpage which you would need to create. There is still some slight work required left to do on your side to enable such a github.io webpage, but as far as I remember, it is not a very daunting task.

If you need any help, just ping me. If you find that this solution is not exactly fitting to your specific needs, feel free to close the PR.  Ping me if you need additional information.

We use a similar mechanism and the pipeline is pretty much the same https://lethe-cfd.github.io/lethe/index.html

Cheers
BB




