### PR TITLE
NORDIC denoising on dMRI images

### DIFF
--- a/functions/02_proc-dwi.sh
+++ b/functions/02_proc-dwi.sh
@@ -23,16 +23,17 @@ nocleanup=$5
 threads=$6
 tmpDir=$7
 dwi_main=$8
-dwi_rpe=$9
-dwi_processed=${10}
-rpe_all=${11}
-regAffine=${12}
-dwi_str=${13}
-b0thr=${14}
-bvalscale=${15}
-synth_reg=${16}
-dwi_upsample=${17}
-PROC=${18}
+dwi_phase=$9
+dwi_rpe=${10}
+dwi_processed=${11}
+rpe_all=${12}
+regAffine=${13}
+dwi_str=${14}
+b0thr=${15}
+bvalscale=${16}
+synth_reg=${17}
+dwi_upsample=${18}
+PROC=${19}
 here=$(pwd)
 
 #------------------------------------------------------------------------------#
@@ -51,6 +52,7 @@ bids_variables "$BIDS" "$id" "$out" "$SES"
 Info "Inputs of proc_dwi"
 Note "tmpDir        :" "$tmpDir"
 Note "dwi_main      :" "$dwi_main"
+Note "dwi_phase     :" "$dwi_phase"
 Note "dwi_rpe       :" "$dwi_rpe"
 Note "rpe_all       :" "$rpe_all"
 Note "dwi_acq       :" "$dwi_str"
@@ -79,6 +81,11 @@ fi
 if [[ "$dwi_main" != "DEFAULT" ]]; then
     IFS=',' read -ra bids_dwis <<< "$dwi_main"
     bids_dwis=("${bids_dwis[@]}")
+fi
+# Manage manual inputs: DWI phase image(s)
+if [[ "$dwi_phase" != "DEFAULT" ]]; then
+    IFS=',' read -ra dwi_phase <<< "$dwi_phase"
+    dwi_phase=("${dwi_phase[@]}")
 fi
 # Manage manual inputs: DWI reverse phase encoding
 if [[ "$dwi_rpe" != "DEFAULT" ]]; then

--- a/micapipe
+++ b/micapipe
@@ -82,6 +82,8 @@ echo -e "
 \t\033[38;5;197m-proc_dwi\033[0m
 \t   \033[38;5;120m-dwi_main\033[0m            : Full path to DWI with N number of directions and b0. If used, it will overwrite the defaults.
 \t\t\t            Default = <bids>/<subject>/dwi/*_dir-AP_dwi.nii*
+\t   \033[38;5;120m-dwi_phase\033[0m           : Full path to DWI phase part with N number of directions. If used, it will overwrite the defaults.
+\t\t\t            Default = <bids>/<subject>/dwi/*_dir-AP_part-phase_dwi.nii*
 \t   \033[38;5;120m-dwi_rpe\033[0m             : DWI b0 image(s) with phase reversal encoding. If used, it will overwrite the defaults.
 \t\t\t            Default = <bids>/<subject>/dwi/<sub>_dir-PA_dwi.nii*
 \t\t\t            Set to 'FALSE' if no DWI with reverse fase encoding will be provided
@@ -455,6 +457,10 @@ do
     dwi_main="$2"
     shift;shift;
   ;;
+  -dwi_phase)
+    dwi_phase="$2"
+    shift;shift;
+  ;;
   -dwi_rpe)
     dwi_rpe="$2"
     shift;shift;
@@ -607,6 +613,14 @@ else
     IFS=',' read -ra dwis_main <<< $dwi_main
     for i in "${!dwis_main[@]}"; do dwis_main[i]=$(realpath ${dwis_main[$i]}); done # Full path
     dwi_main=$(IFS=','; echo "${dwis_main[*]}")
+fi
+# User provided DWI phase image(s)
+if [ -z ${dwi_phase} ]; then
+    dwi_phase=DEFAULT
+else
+    IFS=',' read -ra dwis_phase <<< $dwi_phase
+    for i in "${!dwis_phase[@]}"; do dwis_phase[i]=$(realpath ${dwis_phase[$i]}); done # Full path
+    dwi_phase=$(IFS=','; echo "${dwis_phase[*]}")
 fi
 # User provided DWI reverse phase encoded
 if [ -z ${dwi_rpe} ]; then
@@ -831,7 +845,7 @@ fi
 if [ "$procDWI" = "TRUE" ]; then
     if [[ ${dwi_str} != "DEFAULT" ]]; then log_str=_${dwi_str}; else log_str=""; fi
     log_file_str=$dir_logs/proc_dwi_$(date +'%Y-%m-%d_%H.%M.%S')${log_str}
-    COMMAND="${scriptDir}/02_proc-dwi.sh $BIDS $id $out $SES $nocleanup $threads $tmpDir $dwi_main $dwi_rpe $dwi_processed $rpe_all $regAffine $dwi_str $b0thr $bvalscale $synth_reg $dwi_upsample"
+    COMMAND="${scriptDir}/02_proc-dwi.sh $BIDS $id $out $SES $nocleanup $threads $tmpDir $dwi_main $dwi_phase $dwi_rpe $dwi_processed $rpe_all $regAffine $dwi_str $b0thr $bvalscale $synth_reg $dwi_upsample"
     # mica.q - Diffusion processing
     if [[ $micaq == "TRUE" ]]; then
         Info "MICA qsub - Diffusion processing"


### PR DESCRIPTION
Implements NORDIC denoising for application on dMRI images:

- added flag -dwi_phase, to input phase images necessary for NORDIC denoising. If -dwi_phase has an input then NORDIC denoising is applied else -dwi_phase has no input (DEFAULT or manual) then pipeline is ran as previously.

PR associated with issue #127 