### PR TITLE
Add connectome-workbench to comprehensive base image

### DIFF
--- a/Dockerfile.mamba-base
+++ b/Dockerfile.mamba-base
@@ -213,6 +213,18 @@ RUN . /opt/miniconda-latest/etc/profile.d/conda.sh \
         dcm2niix=1.0.20240202 \
     && mamba clean -afy
 
+# Install Connectome Workbench (provides `wb_command`, required by every micapipe
+# module — init.sh aborts with "WorkBench was not found" otherwise). The bionic
+# apt repo does not ship `connectome-workbench`, so install from conda-forge.
+# Lands at /opt/miniconda-latest/envs/micapipe/bin/wb_command, which is the
+# first path probed by functions/init.sh.
+RUN . /opt/miniconda-latest/etc/profile.d/conda.sh \
+    && echo "🔧 Installing connectome-workbench..." \
+    && mamba install -y -n micapipe -c conda-forge \
+        --override-channels --strict-channel-priority \
+        connectome-workbench \
+    && mamba clean -afy
+
 # Create designer environment
 # Python 3.11 for consistency with micapipe environment and modern package support
 RUN . /opt/miniconda-latest/etc/profile.d/conda.sh \


### PR DESCRIPTION
## Summary
- Install `connectome-workbench` from conda-forge into the micapipe env in `Dockerfile.mamba-base`, so `wb_command` resolves at `/opt/miniconda-latest/envs/micapipe/bin/wb_command` (the first path probed by `functions/init.sh`).

## Why
Server-side verification of [#173](https://github.com/MICA-MNI/micapipe/pull/173) against `ghcr.io/mica-mni/micapipe-comprehensive-base:latest` revealed that `wb_command` is missing from the published comprehensive base image — `which wb_command` returns empty, and the wrapper's dependency check aborts with:

```
[ ERROR ]..... WorkBench was not found
```

This blocks every micapipe pipeline. The bionic apt repo does not ship a `connectome-workbench` package, so conda-forge is the cleanest source and matches the existing chunked `mamba install` pattern used for MRtrix3 and dcm2niix in this Dockerfile.

`functions/init.sh` already preferentially detects `wb_command` inside the conda env (falling back to `/usr/bin`), so no changes are needed there.

## Test plan
- [ ] Rebuild the comprehensive base image from this Dockerfile.
- [ ] Confirm `which wb_command` resolves inside the rebuilt container.
- [ ] Run a micapipe module end-to-end and confirm the WorkBench dependency check passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)