### PR TITLE
Add libxp6 + libosmesa6 system libs to base image

### DIFF
--- a/Dockerfile.mamba-base
+++ b/Dockerfile.mamba-base
@@ -58,6 +58,31 @@ RUN echo "Installing graphics libraries..." && \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
+# Legacy X/Mesa libraries required by AFNI and Connectome Workbench:
+#   - libXp.so.6 (libxp6): AFNI binaries (afni, 3dWarp, ...) link against the
+#     Motif stack. Without it, proc_structural's oblique-correction step
+#     produces no output and the pipeline aborts at "T1w_nativepro was not
+#     generated".
+#   - libOSMesa.so.8 (libosmesa6): wb_command from the conda micapipe env
+#     dynamically loads off-screen Mesa. Without it, every wb_command call
+#     fails with "cannot open shared object file".
+# libxp was dropped from Debian/Ubuntu and is not in bionic main; libosmesa6
+# is in bionic universe but not main. Pull both .debs from the Ubuntu universe
+# pool and install via dpkg + apt-get -f to resolve transitive deps.
+RUN echo "Installing legacy X/Mesa libs (libxp6, libosmesa6) for AFNI + wb_command..." && \
+    apt-get update && \
+    cd /tmp && \
+    wget -q http://archive.ubuntu.com/ubuntu/pool/universe/libx/libxp/libxp6_1.0.2-2_amd64.deb && \
+    wget -q http://archive.ubuntu.com/ubuntu/pool/universe/m/mesa/libosmesa6_18.2.8-0ubuntu0~18.04.2_amd64.deb && \
+    (dpkg -i libxp6_1.0.2-2_amd64.deb libosmesa6_18.2.8-0ubuntu0~18.04.2_amd64.deb || \
+        apt-get install -y --no-install-recommends -f) && \
+    rm -f /tmp/libxp6_1.0.2-2_amd64.deb /tmp/libosmesa6_18.2.8-0ubuntu0~18.04.2_amd64.deb && \
+    ldconfig && \
+    test -e /usr/lib/x86_64-linux-gnu/libXp.so.6 && \
+    test -e /usr/lib/x86_64-linux-gnu/libOSMesa.so.8 && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
 # Scientific computing dependencies
 RUN echo "Installing scientific computing packages..." && \
     apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
## Summary
- Adds `libxp6` (libXp.so.6) and `libosmesa6` (libOSMesa.so.8) to `Dockerfile.mamba-base` so AFNI binaries and `wb_command` can actually load at runtime.
- Discovered while smoke-testing #173 against real data on the BIC server.

## Motivation
With the current base image, two binaries die at load time and take the whole pipeline down with them:

```
afni: error while loading shared libraries: libXp.so.6: cannot open shared object file
wb_command: error while loading shared libraries: libOSMesa.so.8: cannot open shared object file
```

Net effect: `proc_structural`'s oblique-correction step produces no output and the pipeline aborts with `T1w_nativepro was not generated`. So neither AFNI nor Connectome Workbench actually run end-to-end on the published base image right now.

## Why a wget+dpkg dance instead of plain apt
- `libxp` was dropped from Debian/Ubuntu years ago — not in bionic main, and even apt with universe enabled didn't help on the server (`apt install libxp6 libosmesa6` reported `0 newly installed`).
- `libosmesa6` is in bionic universe but not main.

So the change pulls both `.debs` straight from the Ubuntu universe pool by URL and installs them with `dpkg -i`, falling back to `apt-get install -f` to resolve transitive deps. Versions are pinned to what bionic universe ships:

- `libxp6_1.0.2-2_amd64.deb`
- `libosmesa6_18.2.8-0ubuntu0~18.04.2_amd64.deb`

Plus `test -e` checks on `libXp.so.6` and `libOSMesa.so.8` so the layer fails loudly if the layout ever changes.

## Alternative considered
Rebasing the base image from `ubuntu:bionic` to `ubuntu:focal`, where both libs are still in the apt repos, is cleaner long-term but a much bigger lift (FreeSurfer/AFNI/FSL builds all assume bionic). Not in scope for this fix.

## Stacking note
Targeting `enning/comprehensive-cleanup` because `Dockerfile.mamba-base` only exists on that branch — this stacks on top of #173 and rides along when it merges. Discovery context: #173.

## Test plan
- [ ] Trigger the slow `mamba-base-build` workflow once this lands and confirm the new RUN layer succeeds (both `test -e` checks pass).
- [ ] On a freshly built image, run `afni -ver` and `wb_command -version` — neither should print a `cannot open shared object file` error.
- [ ] Re-run the failing real-data smoke test from #173: `proc_structural` should produce `T1w_nativepro` instead of aborting.