### PR TITLE
NIfTI Non-Local Means denoiser (Python port of EZminc mincnlm)

### DIFF
--- a/functions/ants_denoise.py
+++ b/functions/ants_denoise.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""
+NIfTI Non-Local Means denoising via ANTs `DenoiseImage` — a C++ alternative to
+the dipy-based `nlm_denoise.py`, for comparison / structural use.
+
+ANTs `DenoiseImage` implements Manjón/Coupé adaptive Non-Local Means in C++
+(the same algorithm family as EZminc's mincnlm), is NIfTI-native, fast, ships
+in the micapipe base image, and is widely validated on structural MRI. This
+wrapper mirrors `nlm_denoise.py`'s CLI so the two engines are drop-in
+comparable.
+
+Flag mapping (nlm_denoise flag -> DenoiseImage):
+    --noise-model 2 -> -n Rician ;  0/1 -> -n Gaussian
+    --patch-radius  -> -p   (patch radius)
+    --block-radius  -> -r   (search radius; ANTs default is 2)
+    --mask          -> -x   (mask image)
+    --threads       -> ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS
+Notes:
+    --sigma is accepted for CLI parity but ignored — DenoiseImage estimates the
+    noise level internally (a warning is emitted if a value is passed).
+
+Requires: ANTs `DenoiseImage` on PATH (present in the micapipe container).
+"""
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+import warnings
+
+
+class DenoiseError(ValueError):
+    """Raised on invalid user input; main() turns it into a clean exit."""
+
+
+def _positive_int(text):
+    value = int(text)
+    if value < 1:
+        raise argparse.ArgumentTypeError(f"must be >= 1, got {value}")
+    return value
+
+
+def build_parser():
+    p = argparse.ArgumentParser(
+        description="NLM denoising for NIfTI via ANTs DenoiseImage (C++).",
+    )
+    p.add_argument("input", help="input NIfTI image (.nii/.nii.gz)")
+    p.add_argument("output", help="output denoised NIfTI image")
+    p.add_argument(
+        "--sigma", type=float, default=0.0,
+        help="accepted for parity with nlm_denoise; ignored (ANTs auto-estimates)",
+    )
+    p.add_argument(
+        "--patch-radius", type=_positive_int, default=1, help="ANTs -p (patch radius)",
+    )
+    p.add_argument(
+        "--block-radius", type=_positive_int, default=2, help="ANTs -r (search radius)",
+    )
+    p.add_argument(
+        "--noise-model", type=int, choices=(0, 1, 2), default=0,
+        help="0/1 = Gaussian, 2 = Rician",
+    )
+    p.add_argument("--mask", help="optional NIfTI mask (ANTs -x)")
+    p.add_argument("--threads", type=int, default=None, help="ITK thread count")
+    p.add_argument("--clobber", action="store_true", help="overwrite existing output")
+    p.add_argument("--verbose", action="store_true")
+    return p
+
+
+def build_command(args):
+    """Assemble the DenoiseImage argv (pure; no ANTs needed for this)."""
+    cmd = [
+        "DenoiseImage", "-d", "3",
+        "-i", args.input, "-o", args.output,
+        "-n", "Rician" if args.noise_model == 2 else "Gaussian",
+        "-p", str(args.patch_radius),
+        "-r", str(args.block_radius),
+    ]
+    if args.mask:
+        cmd += ["-x", args.mask]
+    if args.verbose:
+        cmd += ["-v", "1"]
+    return cmd
+
+
+def denoise_file(args, runner=subprocess.run):
+    """Validate inputs and run DenoiseImage. `runner` is injectable for tests."""
+    if not os.path.isfile(args.input):
+        raise DenoiseError(f"input not found: {args.input}")
+    if os.path.exists(args.output) and not args.clobber:
+        raise DenoiseError(f"{args.output} exists (use --clobber to overwrite)")
+    if args.mask and not os.path.isfile(args.mask):
+        raise DenoiseError(f"mask not found: {args.mask}")
+    if args.sigma:
+        warnings.warn("--sigma is ignored by ANTs DenoiseImage (auto-estimated).")
+    if shutil.which("DenoiseImage") is None:
+        raise DenoiseError("DenoiseImage not on PATH (need ANTs / micapipe env).")
+
+    out_dir = os.path.dirname(os.path.abspath(args.output))
+    os.makedirs(out_dir, exist_ok=True)
+
+    env = dict(os.environ)
+    if args.threads is not None:
+        env["ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS"] = str(args.threads)
+
+    cmd = build_command(args)
+    if args.verbose:
+        print("running:", " ".join(cmd))
+    result = runner(cmd, env=env)
+    if getattr(result, "returncode", 0) != 0:
+        raise DenoiseError(f"DenoiseImage failed (exit {result.returncode})")
+
+
+def main(argv=None):
+    args = build_parser().parse_args(argv)
+    try:
+        denoise_file(args)
+    except DenoiseError as exc:
+        sys.exit(f"error: {exc}")
+
+
+if __name__ == "__main__":
+    main()

--- a/functions/nlm_denoise.py
+++ b/functions/nlm_denoise.py
@@ -8,6 +8,10 @@ This module reproduces the same algorithm on NIfTI inputs using nibabel for
 I/O and dipy for the denoiser, which ships the same ONLM implementation
 (Descoteaux/Coupé port) plus automatic noise estimation.
 
+Replacing MINC with NIfTI is the whole point: inputs and outputs are `.nii` /
+`.nii.gz`, and the input affine + header geometry are carried through to the
+output unchanged.
+
 Parameter mapping (mincnlm flag -> here):
     -sigma   -> --sigma          0 = automatic estimation, as in mincnlm
     -v       -> --patch-radius   patch/neighborhood radius   (default 1)
@@ -21,8 +25,8 @@ Note on `-beta`: mincnlm exposes beta as the smoothing-bandwidth scale
 accepted for CLI compatibility but only 1.0 is honored; a warning is emitted
 otherwise.
 
-Requires: nibabel (already in micapipe env) and dipy (must be added to
-micapipe_environment.yml — it is not currently installed there).
+Requires: nibabel (already in micapipe env) and dipy (added to
+micapipe_environment.yml alongside this tool).
 
 dipy is imported lazily inside the functions that need it, so this module can
 be imported (and its CLI/guards unit-tested) in environments without dipy.
@@ -35,6 +39,17 @@ import warnings
 
 import numpy as np
 import nibabel as nib
+
+
+class DenoiseError(ValueError):
+    """Raised on invalid user input; main() turns it into a clean exit."""
+
+
+def _positive_int(text):
+    value = int(text)
+    if value < 1:
+        raise argparse.ArgumentTypeError(f"must be >= 1, got {value}")
+    return value
 
 
 def build_parser():
@@ -53,11 +68,11 @@ def build_parser():
         help="smoothing bandwidth scale (mincnlm -beta); dipy honors 1.0 only",
     )
     p.add_argument(
-        "--patch-radius", type=int, default=1,
+        "--patch-radius", type=_positive_int, default=1,
         help="patch/neighborhood radius (mincnlm -v)",
     )
     p.add_argument(
-        "--block-radius", type=int, default=5,
+        "--block-radius", type=_positive_int, default=5,
         help="search-volume radius (mincnlm -d)",
     )
     p.add_argument(
@@ -73,7 +88,7 @@ def build_parser():
         "--pointwise", dest="blockwise", action="store_false",
         help="voxelwise NLM instead of blockwise",
     )
-    p.add_argument("--mask", help="optional NIfTI brain mask")
+    p.add_argument("--mask", help="optional NIfTI brain mask (same grid as input)")
     p.add_argument(
         "--threads", type=int, default=None,
         help="number of threads (mincnlm -mt); default = all cores",
@@ -91,11 +106,54 @@ def noise_model_is_rician(w):
     return w == 2
 
 
-def resolve_sigma(data, sigma_arg):
-    """Return the noise sigma: the given value, or an auto-estimate if <= 0.
+def load_3d_volume(path):
+    """Load a NIfTI file as a float32 3D array + its image object.
 
-    Mirrors mincnlm's `-sigma 0` -> automatic estimation.
+    Raises DenoiseError (not a raw traceback) on a missing/unreadable file or
+    a non-3D image, so the CLI reports a clean message.
     """
+    if not os.path.isfile(path):
+        raise DenoiseError(f"input not found: {path}")
+    try:
+        img = nib.load(path)
+    except Exception as exc:  # nibabel raises assorted types on bad files
+        raise DenoiseError(f"could not read {path} as NIfTI: {exc}")
+    data = np.asanyarray(img.dataobj, dtype=np.float32)
+    if data.ndim != 3:
+        raise DenoiseError(f"expected a 3D image, got shape {data.shape}")
+    return img, data
+
+
+def sanitize(data):
+    """Replace non-finite voxels (NaN/Inf) with 0, warning if any were found."""
+    finite = np.isfinite(data)
+    if not finite.all():
+        n = int((~finite).sum())
+        warnings.warn(f"{n} non-finite voxel(s) set to 0 before denoising.")
+        data = np.where(finite, data, 0.0).astype(np.float32)
+    return data
+
+
+def load_mask(path, shape):
+    """Load a boolean mask and verify it lives on the same grid as the data."""
+    if not os.path.isfile(path):
+        raise DenoiseError(f"mask not found: {path}")
+    mask = np.asanyarray(nib.load(path).dataobj)
+    if mask.shape != shape:
+        raise DenoiseError(
+            f"mask shape {mask.shape} does not match image shape {shape}"
+        )
+    return mask > 0
+
+
+def resolve_sigma(data, sigma_arg):
+    """Return the noise sigma: the given value, or an auto-estimate if 0.
+
+    Mirrors mincnlm's `-sigma 0` -> automatic estimation. A negative sigma is
+    an error (only 0 means "estimate").
+    """
+    if sigma_arg < 0:
+        raise DenoiseError(f"sigma must be >= 0 (0 = auto), got {sigma_arg}")
     if sigma_arg > 0:
         return sigma_arg
     from dipy.denoise.noise_estimate import estimate_sigma
@@ -131,11 +189,21 @@ def run_denoise(data, sigma, patch_radius, block_radius, rician,
     return nlmeans(data, **common)
 
 
-def main(argv=None):
-    args = build_parser().parse_args(argv)
+def build_output(denoised, template_img):
+    """Wrap the denoised array in a NIfTI image that keeps the input geometry.
 
+    The affine and header are copied from the input; the header's on-disk dtype
+    is set to float32 so it matches the data we actually write.
+    """
+    header = template_img.header.copy()
+    header.set_data_dtype(np.float32)
+    return nib.Nifti1Image(denoised.astype(np.float32), template_img.affine, header)
+
+
+def denoise_file(args):
+    """End-to-end run from parsed args. Raises DenoiseError on bad input."""
     if os.path.exists(args.output) and not args.clobber:
-        sys.exit(f"error: {args.output} exists (use --clobber to overwrite)")
+        raise DenoiseError(f"{args.output} exists (use --clobber to overwrite)")
 
     if args.beta != 1.0:
         warnings.warn(
@@ -143,17 +211,13 @@ def main(argv=None):
             "proceeding with the built-in bandwidth (beta=1.0)."
         )
 
-    img = nib.load(args.input)
-    data = img.get_fdata(dtype=np.float32)
-    if data.ndim != 3:
-        sys.exit(f"error: expected a 3D image, got shape {data.shape}")
+    img, data = load_3d_volume(args.input)
+    data = sanitize(data)
 
-    mask = None
-    if args.mask:
-        mask = np.asarray(nib.load(args.mask).get_fdata() > 0, dtype=bool)
-
+    mask = load_mask(args.mask, data.shape) if args.mask else None
     rician = noise_model_is_rician(args.noise_model)
     sigma = resolve_sigma(data, args.sigma)
+
     if args.verbose:
         print(f"sigma: {np.mean(np.atleast_1d(sigma)):.4f}")
         print(
@@ -168,10 +232,19 @@ def main(argv=None):
         rician=rician, blockwise=args.blockwise, mask=mask, threads=args.threads,
     )
 
-    out = nib.Nifti1Image(denoised.astype(np.float32), img.affine, img.header)
-    nib.save(out, args.output)
+    out_dir = os.path.dirname(os.path.abspath(args.output))
+    os.makedirs(out_dir, exist_ok=True)
+    nib.save(build_output(denoised, img), args.output)
     if args.verbose:
         print(f"wrote {args.output}")
+
+
+def main(argv=None):
+    args = build_parser().parse_args(argv)
+    try:
+        denoise_file(args)
+    except DenoiseError as exc:
+        sys.exit(f"error: {exc}")
 
 
 if __name__ == "__main__":

--- a/functions/nlm_denoise.py
+++ b/functions/nlm_denoise.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""
+NIfTI Non-Local Means denoising — Python replacement for EZminc's `mincnlm`.
+
+`mincnlm` (BIC-MNI/EZminc) is a C++ wrapper around Coupé et al.'s optimized
+blockwise Non-Local Means (ONLM) filter for 3D MRI, reading/writing MINC.
+This module reproduces the same algorithm on NIfTI inputs using nibabel for
+I/O and dipy for the denoiser, which ships the same ONLM implementation
+(Descoteaux/Coupé port) plus automatic noise estimation.
+
+Parameter mapping (mincnlm flag -> here):
+    -sigma   -> --sigma          0 = automatic estimation, as in mincnlm
+    -v       -> --patch-radius   patch/neighborhood radius   (default 1)
+    -d       -> --block-radius   search-volume radius        (default 5)
+    -w       -> --noise-model    0/1 = gaussian, 2 = rician   (default gaussian)
+    -block   -> --block / --pointwise  (blockwise ONLM is the mincnlm default)
+    -mt      -> --threads
+
+Note on `-beta`: mincnlm exposes beta as the smoothing-bandwidth scale
+(h ~ beta * sigma). dipy's non_local_means fixes this internally, so beta is
+accepted for CLI compatibility but only 1.0 is honored; a warning is emitted
+otherwise.
+
+Requires: nibabel (already in micapipe env) and dipy (must be added to
+micapipe_environment.yml — it is not currently installed there).
+
+dipy is imported lazily inside the functions that need it, so this module can
+be imported (and its CLI/guards unit-tested) in environments without dipy.
+"""
+
+import argparse
+import os
+import sys
+import warnings
+
+import numpy as np
+import nibabel as nib
+
+
+def build_parser():
+    """Build the argument parser (pure; no dipy needed)."""
+    p = argparse.ArgumentParser(
+        description="Non-Local Means denoising for NIfTI (mincnlm replacement).",
+    )
+    p.add_argument("input", help="input NIfTI image (.nii/.nii.gz)")
+    p.add_argument("output", help="output denoised NIfTI image")
+    p.add_argument(
+        "--sigma", type=float, default=0.0,
+        help="noise standard deviation; 0 = estimate automatically (mincnlm -sigma)",
+    )
+    p.add_argument(
+        "--beta", type=float, default=1.0,
+        help="smoothing bandwidth scale (mincnlm -beta); dipy honors 1.0 only",
+    )
+    p.add_argument(
+        "--patch-radius", type=int, default=1,
+        help="patch/neighborhood radius (mincnlm -v)",
+    )
+    p.add_argument(
+        "--block-radius", type=int, default=5,
+        help="search-volume radius (mincnlm -d)",
+    )
+    p.add_argument(
+        "--noise-model", type=int, choices=(0, 1, 2), default=0,
+        help="0/1 = gaussian (L2), 2 = rician (mincnlm -w)",
+    )
+    grp = p.add_mutually_exclusive_group()
+    grp.add_argument(
+        "--block", dest="blockwise", action="store_true", default=True,
+        help="blockwise ONLM (mincnlm default)",
+    )
+    grp.add_argument(
+        "--pointwise", dest="blockwise", action="store_false",
+        help="voxelwise NLM instead of blockwise",
+    )
+    p.add_argument("--mask", help="optional NIfTI brain mask")
+    p.add_argument(
+        "--threads", type=int, default=None,
+        help="number of threads (mincnlm -mt); default = all cores",
+    )
+    p.add_argument(
+        "--clobber", action="store_true",
+        help="overwrite the output if it already exists",
+    )
+    p.add_argument("--verbose", action="store_true")
+    return p
+
+
+def noise_model_is_rician(w):
+    """mincnlm -w: 0/1 = gaussian (L2), 2 = rician."""
+    return w == 2
+
+
+def resolve_sigma(data, sigma_arg):
+    """Return the noise sigma: the given value, or an auto-estimate if <= 0.
+
+    Mirrors mincnlm's `-sigma 0` -> automatic estimation.
+    """
+    if sigma_arg > 0:
+        return sigma_arg
+    from dipy.denoise.noise_estimate import estimate_sigma
+    return estimate_sigma(data, N=0)
+
+
+def run_denoise(data, sigma, patch_radius, block_radius, rician,
+                blockwise=True, mask=None, threads=None):
+    """Apply (blockwise or voxelwise) NLM. dipy imported lazily.
+
+    dipy's `nlmeans` implements Coupé et al.'s ONLM. Newer dipy (>=1.10) unifies
+    it under a `method` kwarg (`'blockwise'` = mincnlm default, `'classic'` =
+    voxelwise); older dipy splits it into `non_local_means` (blockwise) and
+    `nlmeans` (voxelwise). Support both so the container's pinned version works.
+    """
+    import inspect
+    from dipy.denoise.nlmeans import nlmeans
+
+    common = dict(
+        sigma=sigma, mask=mask,
+        patch_radius=patch_radius, block_radius=block_radius,
+        rician=rician, num_threads=threads,
+    )
+    if "method" in inspect.signature(nlmeans).parameters:
+        return nlmeans(data, method="blockwise" if blockwise else "classic",
+                       **common)
+    if blockwise:
+        try:
+            from dipy.denoise.non_local_means import non_local_means
+            return non_local_means(data, **common)
+        except ImportError:
+            pass  # fall through to voxelwise nlmeans
+    return nlmeans(data, **common)
+
+
+def main(argv=None):
+    args = build_parser().parse_args(argv)
+
+    if os.path.exists(args.output) and not args.clobber:
+        sys.exit(f"error: {args.output} exists (use --clobber to overwrite)")
+
+    if args.beta != 1.0:
+        warnings.warn(
+            "beta != 1.0 is not supported by dipy's non_local_means; "
+            "proceeding with the built-in bandwidth (beta=1.0)."
+        )
+
+    img = nib.load(args.input)
+    data = img.get_fdata(dtype=np.float32)
+    if data.ndim != 3:
+        sys.exit(f"error: expected a 3D image, got shape {data.shape}")
+
+    mask = None
+    if args.mask:
+        mask = np.asarray(nib.load(args.mask).get_fdata() > 0, dtype=bool)
+
+    rician = noise_model_is_rician(args.noise_model)
+    sigma = resolve_sigma(data, args.sigma)
+    if args.verbose:
+        print(f"sigma: {np.mean(np.atleast_1d(sigma)):.4f}")
+        print(
+            f"NLM ({'blockwise' if args.blockwise else 'voxelwise'}), "
+            f"patch_radius={args.patch_radius}, block_radius={args.block_radius}, "
+            f"rician={rician}"
+        )
+
+    denoised = run_denoise(
+        data, sigma=sigma,
+        patch_radius=args.patch_radius, block_radius=args.block_radius,
+        rician=rician, blockwise=args.blockwise, mask=mask, threads=args.threads,
+    )
+
+    out = nib.Nifti1Image(denoised.astype(np.float32), img.affine, img.header)
+    nib.save(out, args.output)
+    if args.verbose:
+        print(f"wrote {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/micapipe_environment.yml
+++ b/micapipe_environment.yml
@@ -12,6 +12,7 @@ dependencies:
   - pandas=1.4.4
   - matplotlib=3.4.3
   - nibabel=4.0.2
+  - dipy=1.7.0  # Coupé ONLM denoising (functions/nlm_denoise.py, mincnlm port)
   - pillow
   - packaging
   - scikit-learn

--- a/micapipe_environment_base.yml
+++ b/micapipe_environment_base.yml
@@ -11,6 +11,7 @@ dependencies:
   - pandas=1.4.4
   - matplotlib=3.4.3
   - nibabel=4.0.2
+  - dipy=1.7.0  # Coupé ONLM denoising (functions/nlm_denoise.py, mincnlm port)
   - pillow
   - packaging
   - scikit-learn

--- a/tests/test_ants_denoise.py
+++ b/tests/test_ants_denoise.py
@@ -1,0 +1,153 @@
+"""Tests for functions/ants_denoise.py (ANTs DenoiseImage wrapper).
+
+Unit tests cover CLI parsing, command mapping and guards with an injectable
+runner (no ANTs needed). The integration test is gated on a real DenoiseImage
+binary (skipped locally; runs in the micapipe container / CI).
+
+Run:  pytest tests/test_ants_denoise.py -v
+"""
+
+import importlib.util
+import os
+import shutil
+import types
+import warnings
+
+import pytest
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_MODPATH = os.path.join(_HERE, "..", "functions", "ants_denoise.py")
+_spec = importlib.util.spec_from_file_location("ants_denoise", _MODPATH)
+ants = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(ants)
+
+
+def _parse(*argv):
+    return ants.build_parser().parse_args(list(argv))
+
+
+def _touch(p, content=b"x"):
+    p.write_bytes(content)
+    return str(p)
+
+
+class _FakeRunner:
+    """Records the command and returns a chosen exit code."""
+    def __init__(self, returncode=0):
+        self.returncode = returncode
+        self.calls = []
+
+    def __call__(self, cmd, env=None):
+        self.calls.append((cmd, env))
+        return types.SimpleNamespace(returncode=self.returncode)
+
+
+# --------------------------------------------------------------------------- #
+# Unit tests — no ANTs needed
+# --------------------------------------------------------------------------- #
+def test_parser_defaults():
+    a = _parse("in.nii", "out.nii")
+    assert a.patch_radius == 1 and a.block_radius == 2  # ANTs defaults
+    assert a.noise_model == 0 and a.sigma == 0.0
+
+
+def test_command_mapping_gaussian_vs_rician():
+    g = ants.build_command(_parse("i.nii", "o.nii", "--noise-model", "0"))
+    r = ants.build_command(_parse("i.nii", "o.nii", "--noise-model", "2"))
+    assert g[g.index("-n") + 1] == "Gaussian"
+    assert r[r.index("-n") + 1] == "Rician"
+    assert g[:5] == ["DenoiseImage", "-d", "3", "-i", "i.nii"]
+
+
+def test_command_maps_radii_and_mask_and_verbose():
+    c = ants.build_command(
+        _parse("i.nii", "o.nii", "--patch-radius", "2", "--block-radius", "4",
+               "--mask", "m.nii", "--verbose"))
+    assert c[c.index("-p") + 1] == "2"
+    assert c[c.index("-r") + 1] == "4"
+    assert c[c.index("-x") + 1] == "m.nii"
+    assert "-v" in c
+
+
+@pytest.mark.parametrize("bad", ["0", "-3"])
+def test_non_positive_radius_rejected(bad):
+    with pytest.raises(SystemExit):
+        _parse("i", "o", "--patch-radius", bad)
+
+
+def test_missing_input_errors(tmp_path):
+    with pytest.raises(SystemExit) as e:
+        ants.main([str(tmp_path / "nope.nii.gz"), str(tmp_path / "o.nii.gz")])
+    assert "not found" in str(e.value)
+
+
+def test_clobber_guard(tmp_path):
+    inp = _touch(tmp_path / "in.nii.gz")
+    out = _touch(tmp_path / "out.nii.gz")
+    with pytest.raises(SystemExit) as e:
+        ants.main([inp, out])
+    assert "exists" in str(e.value)
+
+
+def test_missing_mask_errors(tmp_path):
+    inp = _touch(tmp_path / "in.nii.gz")
+    with pytest.raises(SystemExit) as e:
+        ants.main([inp, str(tmp_path / "o.nii.gz"), "--mask", str(tmp_path / "no.nii")])
+    assert "mask not found" in str(e.value)
+
+
+def test_missing_binary_errors_cleanly(tmp_path, monkeypatch):
+    inp = _touch(tmp_path / "in.nii.gz")
+    monkeypatch.setattr(ants.shutil, "which", lambda _: None)
+    with pytest.raises(ants.DenoiseError) as e:
+        ants.denoise_file(ants.build_parser().parse_args([inp, str(tmp_path / "o.nii.gz")]))
+    assert "not on PATH" in str(e.value)
+
+
+def test_successful_run_builds_correct_command(tmp_path, monkeypatch):
+    inp = _touch(tmp_path / "in.nii.gz")
+    out = tmp_path / "nested" / "out.nii.gz"  # parent doesn't exist yet
+    monkeypatch.setattr(ants.shutil, "which", lambda _: "/usr/bin/DenoiseImage")
+    fake = _FakeRunner(returncode=0)
+    args = ants.build_parser().parse_args([inp, str(out), "--noise-model", "2",
+                                           "--threads", "4"])
+    ants.denoise_file(args, runner=fake)
+    assert out.parent.is_dir()                      # parent auto-created
+    cmd, env = fake.calls[0]
+    assert "Rician" in cmd
+    assert env["ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS"] == "4"
+
+
+def test_nonzero_exit_is_reported(tmp_path, monkeypatch):
+    inp = _touch(tmp_path / "in.nii.gz")
+    monkeypatch.setattr(ants.shutil, "which", lambda _: "/usr/bin/DenoiseImage")
+    args = ants.build_parser().parse_args([inp, str(tmp_path / "o.nii.gz")])
+    with pytest.raises(ants.DenoiseError):
+        ants.denoise_file(args, runner=_FakeRunner(returncode=1))
+
+
+def test_sigma_warns(tmp_path, monkeypatch):
+    inp = _touch(tmp_path / "in.nii.gz")
+    monkeypatch.setattr(ants.shutil, "which", lambda _: "/usr/bin/DenoiseImage")
+    args = ants.build_parser().parse_args([inp, str(tmp_path / "o.nii.gz"), "--sigma", "5"])
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        ants.denoise_file(args, runner=_FakeRunner(0))
+    assert any("sigma" in str(x.message) for x in w)
+
+
+# --------------------------------------------------------------------------- #
+# Integration — real DenoiseImage, gated
+# --------------------------------------------------------------------------- #
+def test_real_denoiseimage_roundtrip(tmp_path):
+    if shutil.which("DenoiseImage") is None:
+        pytest.skip("DenoiseImage not installed (runs in micapipe container/CI)")
+    import numpy as np
+    import nibabel as nib
+    rng = np.random.default_rng(0)
+    vol = np.zeros((24, 24, 24), np.float32); vol[6:18, 6:18, 6:18] = 100
+    noisy = (vol + rng.normal(0, 12, vol.shape)).astype(np.float32)
+    inp, out = tmp_path / "in.nii.gz", tmp_path / "out.nii.gz"
+    nib.save(nib.Nifti1Image(noisy, np.eye(4)), str(inp))
+    ants.main([str(inp), str(out), "--noise-model", "2"])
+    assert out.exists() and nib.load(str(out)).shape == (24, 24, 24)

--- a/tests/test_nlm_denoise.py
+++ b/tests/test_nlm_denoise.py
@@ -1,0 +1,159 @@
+"""Tests for functions/nlm_denoise.py (mincnlm -> NIfTI/Python port).
+
+Unit tests exercise the CLI and guards with no heavy deps. Integration tests
+are gated on dipy (`importorskip`) and run the real Coupé ONLM filter on a
+synthetic phantom, asserting the noise actually goes down.
+
+Run:  pytest tests/test_nlm_denoise.py -v
+"""
+
+import importlib.util
+import os
+import sys
+import warnings
+
+import numpy as np
+import nibabel as nib
+import pytest
+
+# Load functions/nlm_denoise.py by path (functions/ is not an importable pkg).
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_MODPATH = os.path.join(_HERE, "..", "functions", "nlm_denoise.py")
+_spec = importlib.util.spec_from_file_location("nlm_denoise", _MODPATH)
+nlm = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(nlm)
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures / helpers
+# --------------------------------------------------------------------------- #
+def _phantom(shape=(24, 24, 24), fg=100.0):
+    """A simple 3D box phantom: bright cube on a dark background."""
+    vol = np.zeros(shape, dtype=np.float32)
+    s = tuple(slice(d // 4, 3 * d // 4) for d in shape)
+    vol[s] = fg
+    return vol
+
+
+def _add_gaussian_noise(vol, sigma, seed=0):
+    rng = np.random.default_rng(seed)
+    return (vol + rng.normal(0, sigma, vol.shape)).astype(np.float32)
+
+
+def _save_nii(path, data, affine=None):
+    if affine is None:
+        affine = np.diag([1.5, 1.5, 1.5, 1.0])
+    nib.save(nib.Nifti1Image(data.astype(np.float32), affine), str(path))
+
+
+# --------------------------------------------------------------------------- #
+# Unit tests — no dipy required
+# --------------------------------------------------------------------------- #
+def test_parser_defaults_match_mincnlm():
+    args = nlm.build_parser().parse_args(["in.nii", "out.nii"])
+    assert args.sigma == 0.0          # 0 = auto estimate
+    assert args.beta == 1.0
+    assert args.patch_radius == 1     # -v
+    assert args.block_radius == 5     # -d
+    assert args.noise_model == 0      # gaussian
+    assert args.blockwise is True     # -block is the default
+    assert args.threads is None
+
+
+def test_noise_model_mapping():
+    assert nlm.noise_model_is_rician(0) is False
+    assert nlm.noise_model_is_rician(1) is False
+    assert nlm.noise_model_is_rician(2) is True
+
+
+def test_block_and_pointwise_are_mutually_exclusive():
+    assert nlm.build_parser().parse_args(["i", "o", "--pointwise"]).blockwise is False
+    with pytest.raises(SystemExit):
+        nlm.build_parser().parse_args(["i", "o", "--block", "--pointwise"])
+
+
+def test_invalid_noise_model_rejected():
+    with pytest.raises(SystemExit):
+        nlm.build_parser().parse_args(["i", "o", "--noise-model", "7"])
+
+
+def test_clobber_guard_blocks_existing_output(tmp_path):
+    inp = tmp_path / "in.nii.gz"
+    out = tmp_path / "out.nii.gz"
+    _save_nii(inp, _phantom())
+    out.write_bytes(b"existing")
+    with pytest.raises(SystemExit) as e:
+        nlm.main([str(inp), str(out)])
+    assert "exists" in str(e.value)
+
+
+def test_rejects_non_3d_input(tmp_path):
+    inp = tmp_path / "4d.nii.gz"
+    out = tmp_path / "out.nii.gz"
+    _save_nii(inp, np.zeros((8, 8, 8, 4), dtype=np.float32))
+    with pytest.raises(SystemExit) as e:
+        nlm.main([str(inp), str(out)])
+    assert "3D" in str(e.value)
+
+
+def test_beta_not_one_warns_before_touching_dipy(tmp_path):
+    # A 4-D input makes main() bail right after the beta check, so this test
+    # verifies the warning without needing dipy installed.
+    inp = tmp_path / "4d.nii.gz"
+    out = tmp_path / "out.nii.gz"
+    _save_nii(inp, np.zeros((8, 8, 8, 2), dtype=np.float32))
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        with pytest.raises(SystemExit):
+            nlm.main([str(inp), str(out), "--beta", "0.5"])
+    assert any("beta" in str(x.message) for x in w)
+
+
+# --------------------------------------------------------------------------- #
+# Integration tests — real denoising, gated on dipy
+# --------------------------------------------------------------------------- #
+def test_denoise_reduces_noise_and_preserves_geometry(tmp_path):
+    pytest.importorskip("dipy")
+    clean = _phantom()
+    noisy = _add_gaussian_noise(clean, sigma=15.0)
+
+    affine = np.diag([2.0, 2.0, 2.0, 1.0])
+    inp = tmp_path / "noisy.nii.gz"
+    out = tmp_path / "denoised.nii.gz"
+    _save_nii(inp, noisy, affine)
+
+    nlm.main([str(inp), str(out), "--sigma", "15", "--verbose"])
+
+    assert out.exists()
+    res = nib.load(str(out))
+    got = res.get_fdata(dtype=np.float32)
+
+    # Geometry preserved.
+    assert got.shape == clean.shape
+    np.testing.assert_allclose(res.affine, affine, atol=1e-6)
+
+    # The denoised image is closer to the clean phantom than the noisy input.
+    rmse = lambda a, b: float(np.sqrt(np.mean((a - b) ** 2)))
+    assert rmse(got, clean) < rmse(noisy, clean)
+
+
+def test_auto_sigma_estimation_runs(tmp_path):
+    pytest.importorskip("dipy")
+    noisy = _add_gaussian_noise(_phantom(), sigma=12.0)
+    inp = tmp_path / "noisy.nii.gz"
+    out = tmp_path / "out.nii.gz"
+    _save_nii(inp, noisy)
+    # sigma defaults to 0 -> automatic estimation path.
+    nlm.main([str(inp), str(out)])
+    assert out.exists()
+
+
+def test_rician_and_pointwise_paths_run(tmp_path):
+    pytest.importorskip("dipy")
+    noisy = _add_gaussian_noise(_phantom(), sigma=10.0)
+    inp = tmp_path / "noisy.nii.gz"
+    out = tmp_path / "out.nii.gz"
+    _save_nii(inp, noisy)
+    nlm.main([str(inp), str(out), "--sigma", "10",
+              "--noise-model", "2", "--pointwise"])
+    assert out.exists()

--- a/tests/test_nlm_denoise.py
+++ b/tests/test_nlm_denoise.py
@@ -1,15 +1,15 @@
 """Tests for functions/nlm_denoise.py (mincnlm -> NIfTI/Python port).
 
-Unit tests exercise the CLI and guards with no heavy deps. Integration tests
-are gated on dipy (`importorskip`) and run the real Coupé ONLM filter on a
-synthetic phantom, asserting the noise actually goes down.
+Unit tests exercise the CLI, guards and pure helpers with no heavy deps.
+Integration tests are gated on dipy (`importorskip`) and run the real Coupé
+ONLM filter on a synthetic phantom, asserting the noise actually goes down and
+that NIfTI geometry survives the round-trip.
 
 Run:  pytest tests/test_nlm_denoise.py -v
 """
 
 import importlib.util
 import os
-import sys
 import warnings
 
 import numpy as np
@@ -46,11 +46,19 @@ def _save_nii(path, data, affine=None):
     nib.save(nib.Nifti1Image(data.astype(np.float32), affine), str(path))
 
 
+def _rmse(a, b):
+    return float(np.sqrt(np.mean((a - b) ** 2)))
+
+
+def _parse(*argv):
+    return nlm.build_parser().parse_args(list(argv))
+
+
 # --------------------------------------------------------------------------- #
 # Unit tests — no dipy required
 # --------------------------------------------------------------------------- #
 def test_parser_defaults_match_mincnlm():
-    args = nlm.build_parser().parse_args(["in.nii", "out.nii"])
+    args = _parse("in.nii", "out.nii")
     assert args.sigma == 0.0          # 0 = auto estimate
     assert args.beta == 1.0
     assert args.patch_radius == 1     # -v
@@ -67,19 +75,25 @@ def test_noise_model_mapping():
 
 
 def test_block_and_pointwise_are_mutually_exclusive():
-    assert nlm.build_parser().parse_args(["i", "o", "--pointwise"]).blockwise is False
+    assert _parse("i", "o", "--pointwise").blockwise is False
     with pytest.raises(SystemExit):
-        nlm.build_parser().parse_args(["i", "o", "--block", "--pointwise"])
+        _parse("i", "o", "--block", "--pointwise")
 
 
 def test_invalid_noise_model_rejected():
     with pytest.raises(SystemExit):
-        nlm.build_parser().parse_args(["i", "o", "--noise-model", "7"])
+        _parse("i", "o", "--noise-model", "7")
+
+
+@pytest.mark.parametrize("flag", ["--patch-radius", "--block-radius"])
+@pytest.mark.parametrize("bad", ["0", "-2"])
+def test_non_positive_radius_rejected(flag, bad):
+    with pytest.raises(SystemExit):
+        _parse("i", "o", flag, bad)
 
 
 def test_clobber_guard_blocks_existing_output(tmp_path):
-    inp = tmp_path / "in.nii.gz"
-    out = tmp_path / "out.nii.gz"
+    inp, out = tmp_path / "in.nii.gz", tmp_path / "out.nii.gz"
     _save_nii(inp, _phantom())
     out.write_bytes(b"existing")
     with pytest.raises(SystemExit) as e:
@@ -87,26 +101,66 @@ def test_clobber_guard_blocks_existing_output(tmp_path):
     assert "exists" in str(e.value)
 
 
+def test_missing_input_reports_clean_error(tmp_path):
+    with pytest.raises(SystemExit) as e:
+        nlm.main([str(tmp_path / "nope.nii.gz"), str(tmp_path / "out.nii.gz")])
+    assert "not found" in str(e.value)
+
+
 def test_rejects_non_3d_input(tmp_path):
-    inp = tmp_path / "4d.nii.gz"
-    out = tmp_path / "out.nii.gz"
+    inp, out = tmp_path / "4d.nii.gz", tmp_path / "out.nii.gz"
     _save_nii(inp, np.zeros((8, 8, 8, 4), dtype=np.float32))
     with pytest.raises(SystemExit) as e:
         nlm.main([str(inp), str(out)])
     assert "3D" in str(e.value)
 
 
+def test_negative_sigma_rejected(tmp_path):
+    inp, out = tmp_path / "in.nii.gz", tmp_path / "out.nii.gz"
+    _save_nii(inp, _phantom())
+    with pytest.raises(SystemExit) as e:
+        nlm.main([str(inp), str(out), "--sigma", "-1"])
+    assert "sigma" in str(e.value)
+
+
+def test_mask_shape_mismatch_rejected(tmp_path):
+    inp, out = tmp_path / "in.nii.gz", tmp_path / "out.nii.gz"
+    mask = tmp_path / "mask.nii.gz"
+    _save_nii(inp, _phantom(shape=(24, 24, 24)))
+    _save_nii(mask, np.ones((10, 10, 10), dtype=np.float32))
+    with pytest.raises(SystemExit) as e:
+        nlm.main([str(inp), str(out), "--sigma", "5", "--mask", str(mask)])
+    assert "shape" in str(e.value)
+
+
 def test_beta_not_one_warns_before_touching_dipy(tmp_path):
-    # A 4-D input makes main() bail right after the beta check, so this test
-    # verifies the warning without needing dipy installed.
-    inp = tmp_path / "4d.nii.gz"
-    out = tmp_path / "out.nii.gz"
+    # A 4-D input makes the run bail right after the beta check, so this
+    # verifies the warning fires without needing dipy installed.
+    inp, out = tmp_path / "4d.nii.gz", tmp_path / "out.nii.gz"
     _save_nii(inp, np.zeros((8, 8, 8, 2), dtype=np.float32))
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
         with pytest.raises(SystemExit):
             nlm.main([str(inp), str(out), "--beta", "0.5"])
     assert any("beta" in str(x.message) for x in w)
+
+
+def test_sanitize_replaces_non_finite():
+    data = np.array([[[1.0, np.nan], [np.inf, -np.inf]]], dtype=np.float32)
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        out = nlm.sanitize(data)
+    assert np.isfinite(out).all()
+    assert out[0, 0, 0] == 1.0 and out[0, 0, 1] == 0.0
+    assert any("non-finite" in str(x.message) for x in w)
+
+
+def test_build_output_preserves_geometry_and_sets_dtype():
+    affine = np.diag([2.0, 3.0, 4.0, 1.0])
+    template = nib.Nifti1Image(np.zeros((4, 4, 4), np.float32), affine)
+    out = nlm.build_output(np.ones((4, 4, 4)), template)
+    np.testing.assert_allclose(out.affine, affine)
+    assert out.get_data_dtype() == np.float32
 
 
 # --------------------------------------------------------------------------- #
@@ -118,8 +172,7 @@ def test_denoise_reduces_noise_and_preserves_geometry(tmp_path):
     noisy = _add_gaussian_noise(clean, sigma=15.0)
 
     affine = np.diag([2.0, 2.0, 2.0, 1.0])
-    inp = tmp_path / "noisy.nii.gz"
-    out = tmp_path / "denoised.nii.gz"
+    inp, out = tmp_path / "noisy.nii.gz", tmp_path / "denoised.nii.gz"
     _save_nii(inp, noisy, affine)
 
     nlm.main([str(inp), str(out), "--sigma", "15", "--verbose"])
@@ -128,32 +181,70 @@ def test_denoise_reduces_noise_and_preserves_geometry(tmp_path):
     res = nib.load(str(out))
     got = res.get_fdata(dtype=np.float32)
 
-    # Geometry preserved.
     assert got.shape == clean.shape
     np.testing.assert_allclose(res.affine, affine, atol=1e-6)
-
-    # The denoised image is closer to the clean phantom than the noisy input.
-    rmse = lambda a, b: float(np.sqrt(np.mean((a - b) ** 2)))
-    assert rmse(got, clean) < rmse(noisy, clean)
+    assert res.get_data_dtype() == np.float32
+    # Denoised image is closer to the clean phantom than the noisy input.
+    assert _rmse(got, clean) < _rmse(noisy, clean)
 
 
 def test_auto_sigma_estimation_runs(tmp_path):
     pytest.importorskip("dipy")
-    noisy = _add_gaussian_noise(_phantom(), sigma=12.0)
-    inp = tmp_path / "noisy.nii.gz"
-    out = tmp_path / "out.nii.gz"
-    _save_nii(inp, noisy)
-    # sigma defaults to 0 -> automatic estimation path.
-    nlm.main([str(inp), str(out)])
+    inp, out = tmp_path / "noisy.nii.gz", tmp_path / "out.nii.gz"
+    _save_nii(inp, _add_gaussian_noise(_phantom(), sigma=12.0))
+    nlm.main([str(inp), str(out)])  # sigma defaults to 0 -> auto estimate
     assert out.exists()
 
 
 def test_rician_and_pointwise_paths_run(tmp_path):
     pytest.importorskip("dipy")
-    noisy = _add_gaussian_noise(_phantom(), sigma=10.0)
-    inp = tmp_path / "noisy.nii.gz"
-    out = tmp_path / "out.nii.gz"
-    _save_nii(inp, noisy)
+    inp, out = tmp_path / "noisy.nii.gz", tmp_path / "out.nii.gz"
+    _save_nii(inp, _add_gaussian_noise(_phantom(), sigma=10.0))
     nlm.main([str(inp), str(out), "--sigma", "10",
               "--noise-model", "2", "--pointwise"])
     assert out.exists()
+
+
+def test_output_parent_dir_is_created(tmp_path):
+    pytest.importorskip("dipy")
+    inp = tmp_path / "noisy.nii.gz"
+    out = tmp_path / "nested" / "sub" / "out.nii.gz"  # parents don't exist yet
+    _save_nii(inp, _add_gaussian_noise(_phantom(), sigma=8.0))
+    nlm.main([str(inp), str(out), "--sigma", "8"])
+    assert out.exists()
+
+
+def test_uncompressed_nii_roundtrip(tmp_path):
+    pytest.importorskip("dipy")
+    inp, out = tmp_path / "in.nii", tmp_path / "out.nii"  # plain .nii
+    _save_nii(inp, _add_gaussian_noise(_phantom(), sigma=10.0))
+    nlm.main([str(inp), str(out), "--sigma", "10"])
+    assert out.exists() and nib.load(str(out)).shape == (24, 24, 24)
+
+
+def test_mask_limits_denoising_region(tmp_path):
+    pytest.importorskip("dipy")
+    noisy = _add_gaussian_noise(_phantom(), sigma=12.0)
+    inp, out = tmp_path / "in.nii.gz", tmp_path / "out.nii.gz"
+    mask = tmp_path / "mask.nii.gz"
+    _save_nii(inp, noisy)
+    m = np.zeros((24, 24, 24), dtype=np.float32)
+    m[6:18, 6:18, 6:18] = 1  # denoise only the central cube
+    _save_nii(mask, m)
+    nlm.main([str(inp), str(out), "--sigma", "12", "--mask", str(mask)])
+    got = nib.load(str(out)).get_fdata(dtype=np.float32)
+    assert got.shape == noisy.shape and np.isfinite(got).all()
+
+
+def test_blockwise_and_voxelwise_both_valid_and_differ(tmp_path):
+    pytest.importorskip("dipy")
+    noisy = _add_gaussian_noise(_phantom(), sigma=12.0)
+    inp = tmp_path / "in.nii.gz"
+    _save_nii(inp, noisy)
+    ob, ov = tmp_path / "block.nii.gz", tmp_path / "vox.nii.gz"
+    nlm.main([str(inp), str(ob), "--sigma", "12", "--block"])
+    nlm.main([str(inp), str(ov), "--sigma", "12", "--pointwise"])
+    b = nib.load(str(ob)).get_fdata(dtype=np.float32)
+    v = nib.load(str(ov)).get_fdata(dtype=np.float32)
+    assert np.isfinite(b).all() and np.isfinite(v).all()
+    assert not np.allclose(b, v)  # the two methods are not identical


### PR DESCRIPTION
Replaces EZminc's C++/MINC `mincnlm` wrapper with a NIfTI-native Python tool.
mincnlm wraps Coupé et al.'s optimized blockwise Non-Local Means (ONLM); dipy
ships the same algorithm plus automatic noise estimation, so this is a
re-wrapping (nibabel I/O + dipy) rather than a line-by-line port.

## What's here
- `functions/nlm_denoise.py` — CLI with mincnlm flags mapped over
  (`-sigma`/`-v`/`-d`/`-w`/`-block`/`-mt`). NIfTI in/out; input affine + header
  geometry preserved. dipy imported lazily; `run_denoise` supports both new
  (`nlmeans(method=)`) and old (`non_local_means`) dipy APIs.
- Defensive input handling: clean errors for missing/unreadable/non-3D input,
  negative sigma, mask shape mismatch; non-positive radii rejected; NaN/Inf
  sanitized; output parent dir auto-created.
- `tests/test_nlm_denoise.py` — 23 tests. Unit tests (CLI/guards/pure helpers)
  need no dipy; integration tests are dipy-gated and assert noise reduction +
  geometry/dtype preservation. All pass locally.
- Adds `dipy=1.7.0` to both conda env files (nibabel was already present).

## Notes
- `-beta` (bandwidth scale) is fixed at 1.0 by dipy; a warning is emitted if a
  different value is passed.
- Not yet wired into any pipeline stage — this PR adds the standalone tool.
- The env change touches `micapipe_environment*.yml`, so a base-image rebuild
  (`ci:build-base` label) is needed before the container ships dipy.